### PR TITLE
add delete content

### DIFF
--- a/src/application/dto/input/category/category.delete.input.dto.ts
+++ b/src/application/dto/input/category/category.delete.input.dto.ts
@@ -1,0 +1,15 @@
+import { InputDto } from '../input.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, Min } from 'class-validator';
+
+export class CategoryDeleteInputDto implements InputDto {
+  @ApiProperty({
+    example: '1',
+    description: 'カテゴリーID',
+    type: String,
+  })
+  @IsNotEmpty()
+  @IsNumber()
+  @Min(1)
+  categoryId: number;
+}

--- a/src/application/dto/output/category/category.delete.ouput.builder.spec.ts
+++ b/src/application/dto/output/category/category.delete.ouput.builder.spec.ts
@@ -1,0 +1,31 @@
+import { CategoryDeleteOutputBuilder } from './category.delete.output.builder';
+import { CategoryDeleteOutputDto } from './category.delete.output.dto';
+
+describe('CategoryDeleteOutputBuilder', () => {
+  it('CategoryDeleteOutputDto をビルドすることができること', () => {
+    // テストデータを準備
+    const id = 1;
+    const name = 'Test Category';
+    const description = 'Test Description';
+    const createdAt = new Date('2025-03-20T08:51:00.000Z');
+    const updatedAt = new Date('2025-03-20T08:51:00.000Z');
+    const deletedAt = new Date('2025-03-20T08:51:00.000Z');
+
+    const builder = new CategoryDeleteOutputBuilder(
+      id,
+      name,
+      description,
+      createdAt,
+      updatedAt,
+      deletedAt
+    );
+    const result = builder.build();
+    expect(result).toBeInstanceOf(CategoryDeleteOutputDto);
+    expect(result.id).toBe(id);
+    expect(result.name).toBe(name);
+    expect(result.description).toBe(description);
+    expect(result.createdAt).toBe(createdAt);
+    expect(result.updatedAt).toBe(updatedAt);
+    expect(result.deletedAt).toBe(deletedAt);
+  });
+});

--- a/src/application/dto/output/category/category.delete.output.builder.ts
+++ b/src/application/dto/output/category/category.delete.output.builder.ts
@@ -1,0 +1,41 @@
+import { OutputBuilder } from '../../output/output.builder';
+import { CategoryDeleteOutputDto } from './category.delete.output.dto';
+
+export class CategoryDeleteOutputBuilder
+  implements OutputBuilder<CategoryDeleteOutputDto>
+{
+  private _id: number;
+  private _name: string;
+  private _description: string;
+  private _createdAt: Date;
+  private _updatedAt: Date;
+  private _deletedAt: Date;
+
+  constructor(
+    id: number,
+    name: string,
+    description: string,
+    createdAt: Date,
+    updatedAt: Date,
+    deletedAt: Date
+  ) {
+    this._id = id;
+    this._name = name;
+    this._description = description;
+    this._createdAt = createdAt;
+    this._updatedAt = updatedAt;
+    this._deletedAt = deletedAt;
+  }
+  build(): CategoryDeleteOutputDto {
+    return (() => {
+      const output = new CategoryDeleteOutputDto();
+      output.id = this._id;
+      output.name = this._name;
+      output.description = this._description;
+      output.createdAt = this._createdAt;
+      output.updatedAt = this._updatedAt;
+      output.deletedAt = this._deletedAt;
+      return output;
+    })();
+  }
+}

--- a/src/application/dto/output/category/category.delete.output.dto.ts
+++ b/src/application/dto/output/category/category.delete.output.dto.ts
@@ -1,0 +1,66 @@
+import 'reflect-metadata';
+import { OutputDto } from '../output.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+
+export class CategoryDeleteOutputDto implements OutputDto {
+  @ApiProperty({
+    example: 1,
+    description: `
+    カテゴリーID
+    `,
+    type: Number,
+  })
+  @Expose({ name: 'id' })
+  id: number;
+
+  @ApiProperty({
+    example: 'テストカテゴリー',
+    description: `
+    カテゴリー名
+    `,
+    type: String,
+  })
+  @Expose({ name: 'name' })
+  name: string;
+
+  @ApiProperty({
+    example: 'このカテゴリーはテスト用です。',
+    description: `
+    カテゴリーの詳細
+    `,
+    type: String,
+  })
+  @Expose({ name: 'description' })
+  description: string;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+    作成日時
+    `,
+    type: Date,
+  })
+  @Expose({ name: 'created_at' })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+    更新日時
+    `,
+    type: Date,
+  })
+  @Expose({ name: 'updated_at' })
+  updatedAt: Date;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+    削除日時
+    `,
+    type: Date,
+  })
+  @Expose({ name: 'deleted_at' })
+  deletedAt: Date;
+}

--- a/src/application/services/category/category.delete.interface.ts
+++ b/src/application/services/category/category.delete.interface.ts
@@ -1,0 +1,9 @@
+import { CategoryDeleteInputDto } from '../../../application/dto/input/category/category.delete.input.dto';
+import { CategoryDeleteOutputDto } from '../../../application/dto/output/category/category.delete.output.dto';
+import { ApplicationService } from '../application.service';
+import { CategoriesDatasource } from '../../../infrastructure/datasources/categories/categories.datasource';
+
+export interface CategoryDeleteServiceInterface
+  extends ApplicationService<CategoryDeleteInputDto, CategoryDeleteOutputDto> {
+  categoriesDatasource: CategoriesDatasource;
+}

--- a/src/application/services/category/category.delete.service.spec.ts
+++ b/src/application/services/category/category.delete.service.spec.ts
@@ -1,0 +1,311 @@
+import {
+  ConflictException,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoryDeleteService } from './category.delete.service';
+import { CategoriesDatasource } from '../../../infrastructure/datasources/categories/categories.datasource';
+import { CategoryDeleteInputDto } from 'src/application/dto/input/category/category.delete.input.dto';
+import { CategoryDeleteOutputDto } from 'src/application/dto/output/category/category.delete.output.dto';
+import { of, throwError } from 'rxjs';
+
+describe('CategoryDeleteService', () => {
+  let categoryDeleteService: CategoryDeleteService;
+  let categoriesDatasource: CategoriesDatasource;
+  let logger: Logger;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CategoryDeleteService,
+        {
+          provide: CategoriesDatasource,
+          useValue: {
+            findByCategoryId: jest.fn(),
+            deleteCategory: jest.fn(),
+          },
+        },
+        {
+          provide: Logger,
+          useValue: {
+            log: jest.fn(),
+            error: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    categoryDeleteService = module.get<CategoryDeleteService>(
+      CategoryDeleteService
+    );
+    categoriesDatasource =
+      module.get<CategoriesDatasource>(CategoriesDatasource);
+    logger = module.get<Logger>(Logger);
+  });
+
+  it('should be defined', () => {
+    expect(categoryDeleteService).toBeDefined();
+  });
+
+  it('カテゴリを論理削除すること', (done) => {
+    const categoryId = 1;
+    const category = {
+      id: categoryId,
+      name: 'Test Category',
+      description: 'Test Category Description',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+      itemCategories: [],
+    };
+    const inputDto: CategoryDeleteInputDto = {
+      categoryId: categoryId,
+    };
+    const outputDto: CategoryDeleteOutputDto = {
+      id: categoryId,
+      name: 'Test Category',
+      description: 'Test Category Description',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: new Date(),
+    };
+
+    jest
+      .spyOn(categoriesDatasource, 'findByCategoryId')
+      .mockReturnValue(of(category));
+    jest
+      .spyOn(categoriesDatasource, 'deleteCategory')
+      .mockReturnValue(of(void 0));
+    jest.spyOn(logger, 'log');
+
+    categoryDeleteService.service(inputDto).subscribe({
+      next: (result) => {
+        expect(result.id).toBe(outputDto.id);
+        expect(result.name).toBe(outputDto.name);
+        expect(result.description).toBe(outputDto.description);
+        expect(result.createdAt.getTime()).toBeCloseTo(
+          outputDto.createdAt.getTime(),
+          -1
+        );
+        expect(result.updatedAt.getTime()).toBeCloseTo(
+          outputDto.updatedAt.getTime(),
+          -1
+        );
+        expect(result.deletedAt.getTime()).toBeCloseTo(
+          outputDto.deletedAt.getTime(),
+          -1
+        );
+      },
+      error: (error) => {
+        done.fail(error);
+      },
+      complete: () => {
+        done();
+      },
+    });
+  });
+
+  it('カテゴリが存在しないとき、404エラーを返すこと', (done) => {
+    const categoryId = 1;
+    const inputDto: CategoryDeleteInputDto = {
+      categoryId: categoryId,
+    };
+
+    jest
+      .spyOn(categoriesDatasource, 'findByCategoryId')
+      .mockReturnValue(of(null));
+    jest.spyOn(logger, 'error');
+
+    categoryDeleteService.service(inputDto).subscribe({
+      next: () => {
+        done.fail('Unexpected result');
+      },
+      error: (error) => {
+        expect(error).toBeInstanceOf(NotFoundException);
+        expect(error.message).toBe('Category not found');
+        done();
+      },
+      complete: () => {
+        done();
+      },
+    });
+  });
+
+  it('外部のテーブルで利用されているとき、409エラーを返すこと', (done) => {
+    const categoryId = 1;
+    const category = {
+      id: categoryId,
+      name: 'Test Category',
+      description: 'Test Category Description',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+      itemCategories: [],
+    };
+    const inputDto: CategoryDeleteInputDto = {
+      categoryId: categoryId,
+    };
+
+    jest
+      .spyOn(categoriesDatasource, 'findByCategoryId')
+      .mockReturnValue(of(category));
+    jest
+      .spyOn(categoriesDatasource, 'deleteCategory')
+      .mockReturnValue(throwError(() => ({ code: 'ER_ROW_IS_REFERENCED' })));
+    categoryDeleteService.service(inputDto).subscribe({
+      next: () => {
+        done.fail('Unexpected result');
+      },
+      error: (error) => {
+        expect(error).toBeInstanceOf(ConflictException);
+        expect(error.message).toBe(
+          'This category cannot be deleted due to related data!'
+        );
+        done();
+      },
+      complete: () => {
+        done();
+      },
+    });
+  });
+
+  it('カテゴリの削除に失敗したとき、500エラーを返すこと', (done) => {
+    const categoryId = 1;
+    const category = {
+      id: categoryId,
+      name: 'Test Category',
+      description: 'Test Category Description',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+      itemCategories: [],
+    };
+    const inputDto: CategoryDeleteInputDto = {
+      categoryId: categoryId,
+    };
+
+    jest
+      .spyOn(categoriesDatasource, 'findByCategoryId')
+      .mockReturnValue(of(category));
+    jest
+      .spyOn(categoriesDatasource, 'deleteCategory')
+      .mockReturnValue(
+        throwError(() => new Error('Transaction processing failed'))
+      );
+
+    jest.spyOn(logger, 'error');
+    categoryDeleteService.service(inputDto).subscribe({
+      next: () => {
+        done.fail('Unexpected result');
+      },
+      error: (error) => {
+        expect(error).toBeInstanceOf(InternalServerErrorException);
+        expect(error.message).toBe('Transaction processing failed');
+        done();
+      },
+      complete: () => {
+        done();
+      },
+    });
+  });
+
+  it('カテゴリの論理削除が成功したとき、成功logを出力すること', (done) => {
+    const categoryId = 1;
+    const category = {
+      id: categoryId,
+      name: 'Test Category',
+      description: 'Test Category Description',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+      itemCategories: [],
+    };
+    const inputDto: CategoryDeleteInputDto = {
+      categoryId: categoryId,
+    };
+    const outputDto: CategoryDeleteOutputDto = {
+      id: categoryId,
+      name: 'Test Category',
+      description: 'Test Category Description',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: new Date(),
+    };
+    jest
+      .spyOn(categoriesDatasource, 'findByCategoryId')
+      .mockReturnValue(of(category));
+    jest
+      .spyOn(categoriesDatasource, 'deleteCategory')
+      .mockReturnValue(of(void 0));
+    jest.spyOn(logger, 'log');
+
+    categoryDeleteService.service(inputDto).subscribe({
+      next: (result) => {
+        logger.log(`Category deleted successfully: ${outputDto.id}`);
+        expect(result.id).toBe(outputDto.id);
+        expect(result.name).toBe(outputDto.name);
+        expect(result.description).toBe(outputDto.description);
+        expect(result.createdAt.getTime()).toBeCloseTo(
+          outputDto.createdAt.getTime(),
+          -1
+        );
+        expect(result.updatedAt.getTime()).toBeCloseTo(
+          outputDto.updatedAt.getTime(),
+          -1
+        );
+        expect(result.deletedAt.getTime()).toBeCloseTo(
+          outputDto.deletedAt.getTime(),
+          -1
+        );
+      },
+      error: (error) => {
+        done.fail(error);
+      },
+      complete: () => {
+        done();
+      },
+    });
+  });
+
+  it('カテゴリの論理削除に失敗したとき、エラーログを出力すること', (done) => {
+    const categoryId = 1;
+    const category = {
+      id: categoryId,
+      name: 'Test Category',
+      description: 'Test Category Description',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+      itemCategories: [],
+    };
+    const inputDto: CategoryDeleteInputDto = {
+      categoryId: categoryId,
+    };
+    jest
+      .spyOn(categoriesDatasource, 'findByCategoryId')
+      .mockReturnValue(of(category));
+    jest
+      .spyOn(categoriesDatasource, 'deleteCategory')
+      .mockReturnValue(
+        throwError(() => new Error('Transaction processing failed'))
+      );
+    jest.spyOn(logger, 'error');
+
+    categoryDeleteService.service(inputDto).subscribe({
+      next: () => {
+        done.fail('Unexpected result');
+      },
+      error: (error) => {
+        logger.error(`Error deleting category: ${error.message}`);
+        expect(error).toBeInstanceOf(InternalServerErrorException);
+        expect(error.message).toBe('Transaction processing failed');
+        done();
+      },
+      complete: () => {
+        done();
+      },
+    });
+  });
+});

--- a/src/application/services/category/category.delete.service.ts
+++ b/src/application/services/category/category.delete.service.ts
@@ -1,0 +1,72 @@
+import {
+  ConflictException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { catchError, map, Observable, switchMap, throwError } from 'rxjs';
+import { CategoryDeleteInputDto } from '../../dto/input/category/category.delete.input.dto';
+import { CategoryDeleteOutputDto } from '../../dto/output/category/category.delete.output.dto';
+import { CategoryDeleteServiceInterface } from './category.delete.interface';
+import { CategoriesDatasource } from '../../../infrastructure/datasources/categories/categories.datasource';
+import { CategoryDeleteOutputBuilder } from '../../dto/output/category/category.delete.output.builder';
+import { CategoryDomainFactory } from '../../../domain/inventory/items/factories/category.domain.factory';
+import { Logger } from '@nestjs/common';
+
+@Injectable()
+export class CategoryDeleteService implements CategoryDeleteServiceInterface {
+  private readonly logger = new Logger(CategoryDeleteService.name);
+
+  constructor(public readonly categoriesDatasource: CategoriesDatasource) {}
+
+  service(input: CategoryDeleteInputDto): Observable<CategoryDeleteOutputDto> {
+    const { categoryId } = input;
+
+    this.logger.log(`Starting delete for category with ID: ${categoryId}`);
+
+    return this.categoriesDatasource.findByCategoryId(categoryId).pipe(
+      switchMap((categories) => {
+        if (!categories) {
+          return throwError(() => new NotFoundException('Category not found'));
+        }
+        //ファクトリでドメインエンティティに変換
+        const category = CategoryDomainFactory.fromInfrastructure(categories);
+        const deletedCategory = category.delete();
+        return this.categoriesDatasource
+          .deleteCategory(deletedCategory.id)
+          .pipe(
+            map(() => {
+              this.logger.log(
+                `Category deleted successfully: ${deletedCategory.id}`
+              );
+              const builder = new CategoryDeleteOutputBuilder(
+                deletedCategory.id,
+                deletedCategory.name,
+                deletedCategory.description,
+                deletedCategory.createdAt,
+                deletedCategory.updatedAt,
+                deletedCategory.deletedAt
+              );
+              return builder.build();
+            }),
+            catchError((error) => this.handleDeleteError(error))
+          );
+      })
+    );
+  }
+
+  private handleDeleteError(error: any): Observable<never> {
+    if (error.code === 'ER_ROW_IS_REFERENCED') {
+      return throwError(
+        () =>
+          new ConflictException(
+            'This category cannot be deleted due to related data!'
+          )
+      );
+    }
+    this.logger.error('Error deleting category:', error);
+    return throwError(
+      () => new InternalServerErrorException('Transaction processing failed')
+    );
+  }
+}

--- a/src/domain/inventory/items/entities/category.entity.spec.ts
+++ b/src/domain/inventory/items/entities/category.entity.spec.ts
@@ -106,4 +106,43 @@ describe('Category Entity', () => {
       expect(updatedCategory).toBeNull();
     });
   });
+
+  describe('isDeleted', () => {
+    it('deletedAtがnullの場合、falseを返す', () => {
+      expect(category.isDeleted()).toBe(false);
+    });
+
+    it('deletedAtがnullでない場合、trueを返す', () => {
+      const deletedCategory = new Category(
+        1,
+        'Category 1',
+        'Description',
+        new Date(),
+        new Date(),
+        new Date()
+      );
+      expect(deletedCategory.isDeleted()).toBe(true);
+    });
+  });
+
+  describe('delete', () => {
+    it('deletedAtがnullの場合、deletedAtに現在の日時を設定する', () => {
+      const deletedCategory = category.delete();
+      expect(deletedCategory.deletedAt).not.toBeNull();
+    });
+
+    it('deletedAtがnullでない場合、何もしない', () => {
+      const deletedCategory = new Category(
+        1,
+        'Category 1',
+        'Description',
+        new Date(),
+        new Date(),
+        new Date()
+      );
+      const originalDeletedAt = deletedCategory.deletedAt;
+      const updatedCategory = deletedCategory.delete();
+      expect(updatedCategory.deletedAt).toBe(originalDeletedAt);
+    });
+  });
 });

--- a/src/domain/inventory/items/entities/category.entity.ts
+++ b/src/domain/inventory/items/entities/category.entity.ts
@@ -47,6 +47,10 @@ export class Category {
     return this._deletedAt;
   }
 
+  isDeleted(): boolean {
+    return this._deletedAt !== null;
+  }
+
   validateUpdate(name?: string, description?: string): boolean {
     // 未定義の場合
     if (name === undefined || description === undefined) {
@@ -105,5 +109,18 @@ export class Category {
     }
 
     return null;
+  }
+
+  delete(): Category {
+    return this._deletedAt !== null
+      ? this
+      : new Category(
+          this._id,
+          this._name,
+          this._description,
+          this._createdAt,
+          new Date(),
+          new Date()
+        );
   }
 }

--- a/src/infrastructure/datasources/categories/categories.datasource.ts
+++ b/src/infrastructure/datasources/categories/categories.datasource.ts
@@ -181,4 +181,24 @@ export class CategoriesDatasource {
       map(() => {}) // `UpdateResult` を無視して `void` を返す
     );
   }
+
+  /**
+   * 入力idに該当するカテゴリー情報を論理削除する
+   * @param id
+   * @returns なし
+   */
+  deleteCategory(id: number): Observable<void> {
+    return from(
+      this.dataSource
+        .createQueryBuilder()
+        .update(Categories)
+        .set({
+          updatedAt: new Date(),
+          deletedAt: new Date(),
+        })
+        .where('id = :id', { id })
+        .andWhere('deletedAt IS NULL')
+        .execute()
+    ).pipe(map(() => {}));
+  }
 }

--- a/src/presentation/controllers/category/category.controller.ts
+++ b/src/presentation/controllers/category/category.controller.ts
@@ -7,10 +7,12 @@ import {
   Patch,
   Post,
   Query,
+  Delete,
 } from '@nestjs/common';
 import { CategoryListServiceInterface } from '../../../application/services/category/category.list.interface';
 import { CategoryRegisterServiceInterface } from '../../../application/services/category/category.register.interface';
 import { CategoryUpdateServiceInterface } from '../../../application/services/category/category.update.interface';
+import { CategoryDeleteServiceInterface } from '../../../application/services/category/category.delete.interface';
 import { Observable } from 'rxjs';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CategoryListInputDto } from '../../../application/dto/input/category/category.list.input.dto';
@@ -19,6 +21,8 @@ import { CategoryRegisterInputDto } from '../../../application/dto/input/categor
 import { CategoryRegisterOutputDto } from '../../../application/dto/output/category/category.register.output.dto';
 import { CategoryUpdateInputDto } from '../../../application/dto/input/category/category.update.input.dto';
 import { CategoryUpdateOutputDto } from '../../../application/dto/output/category/category.update.output.dto';
+import { CategoryDeleteInputDto } from '../../../application/dto/input/category/category.delete.input.dto';
+import { CategoryDeleteOutputDto } from '../../../application/dto/output/category/category.delete.output.dto';
 
 @ApiTags('categories')
 @Controller('categories')
@@ -29,7 +33,9 @@ export class CategoryListController {
     @Inject('CategoryRegisterServiceInterface')
     private readonly CategoryRegisterService: CategoryRegisterServiceInterface,
     @Inject('CategoryUpdateServiceInterface')
-    private readonly CategoryUpdateService: CategoryUpdateServiceInterface
+    private readonly CategoryUpdateService: CategoryUpdateServiceInterface,
+    @Inject('CategoryDeleteServiceInterface')
+    private readonly CategoryDeleteService: CategoryDeleteServiceInterface
   ) {}
 
   /**
@@ -91,5 +97,26 @@ export class CategoryListController {
     @Body() body: CategoryUpdateInputDto
   ): Observable<CategoryUpdateOutputDto> {
     return this.CategoryUpdateService.service(body, categoryId);
+  }
+
+  /**
+   * @param request - リクエスト情報
+   * @return {Observable<CategoryDeleteOutputDto>} - カテゴリ情報を含むObservable
+   */
+  @Delete(':category_id')
+  @ApiOperation({
+    summary: 'カテゴリ情報を1件削除するエンドポイント',
+    description: 'カテゴリ情報を1件削除するAPI',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Deleted',
+    type: CategoryDeleteOutputDto,
+  })
+  deleteCategory(
+    @Param('category_id') categoryId: number
+  ): Observable<CategoryDeleteOutputDto> {
+    const request: CategoryDeleteInputDto = { categoryId };
+    return this.CategoryDeleteService.service(request);
   }
 }

--- a/src/presentation/modules/categories.module.ts
+++ b/src/presentation/modules/categories.module.ts
@@ -4,6 +4,7 @@ import { CategoryListController } from '../controllers/category/category.control
 import { CategoryListService } from '../../application/services/category/category.list.service';
 import { CategoryRegisterService } from '../../application/services/category/category.register.service';
 import { CategoryUpdateService } from '../../application/services/category/category.update.service';
+import { CategoryDeleteService } from '../../application/services/category/category.delete.service';
 import { CategoryDomainService } from '../../domain/inventory/items/services/category.domain.service';
 import { DatabaseModule } from './database.module';
 import { CategoriesDatasource } from '../../infrastructure/datasources/categories/categories.datasource';
@@ -26,6 +27,10 @@ import { CategoriesDatasource } from '../../infrastructure/datasources/categorie
       useClass: CategoryUpdateService,
     },
     {
+      provide: 'CategoryDeleteServiceInterface',
+      useClass: CategoryDeleteService,
+    },
+    {
       provide: CategoryDomainService,
       useClass: CategoryDomainService,
     },
@@ -35,6 +40,7 @@ import { CategoriesDatasource } from '../../infrastructure/datasources/categorie
     'CategoryListServiceInterface',
     'CategoryRegisterServiceInterface',
     'CategoryUpdateServiceInterface',
+    'CategoryDeleteServiceInterface',
     CategoryDomainService,
   ],
 })


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#51 
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- controllerの追加
- I/Oの追加
- クエリの追加
- アプリケーションサービスの追加
- エンティティに振る舞いを追加
- ユニットテストの追加
- swaggerによるドキュメントを追加

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
- 確認済み

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
1. アプリケーションサーバーを起動する
```
npm run start:dev
```

2. postmanなどで確認する

## 動作したときのスクリーンショット
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
### log情報
```
[Nest] 85127  - 2025/03/22 10:57:08     LOG [CategoryDeleteService] Starting delete for category with ID: 15
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt, `categories`.`deleted_at` AS deletedAt FROM `categories` `categories` WHERE ( `categories`.`id` = ? AND `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) -- PARAMETERS: [15]
query: UPDATE `categories` SET `updated_at` = ?, `deleted_at` = ? WHERE `id` = ? AND `deleted_at` IS NULL -- PARAMETERS: ["2025-03-22T01:57:08.103Z","2025-03-22T01:57:08.103Z",15]
[Nest] 85127  - 2025/03/22 10:57:08     LOG [CategoryDeleteService] Category deleted successfully: 15
[Nest] 85127  - 2025/03/22 10:57:08     LOG [LoggerInterceptor.name] Response: [DELETE] /categories/15 29ms - {"id":15,"name":"huga10","description":"カテゴリーの説明","createdAt":"2025-03-01T16:26:01.000Z","updatedAt":"2025-03-22T01:57:08.103Z","deletedAt":"2025-03-22T01:57:08.103Z"}
```

### DB上でも論理削除が確認できる
<img width="1512" alt="スクリーンショット 2025-03-22 10 57 35" src="https://github.com/user-attachments/assets/40b791c0-9a42-4a5d-808d-9ea39c9cd241" />

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->