### PR TITLE
fix：カテゴリ一覧取得のドメインオブジェクトの生成の責務を変更

### DIFF
--- a/src/application/dto/output/category/category.list.output.builder.spec.ts
+++ b/src/application/dto/output/category/category.list.output.builder.spec.ts
@@ -1,83 +1,54 @@
 import { CategoryListOutputBuilder } from './category.list.output.builder';
 import { CategoryListOutputDto } from './category.list.output.dto';
 import { HttpException, HttpStatus } from '@nestjs/common';
-import { map, of } from 'rxjs';
-import { Categories } from '../../../../infrastructure/orm/entities/categories.entity';
+import { Category } from '../../../../domain/inventory/items/entities/category.entity';
 
 describe('CategoryListOutputBuilder', () => {
-  const mockCategories: Categories[] = [
-    {
-      id: 1,
-      name: 'Category 1',
-      description: 'Description 1',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      deletedAt: null,
-      itemCategories: [],
-    },
-    {
-      id: 2,
-      name: 'Category 2',
-      description: 'Description 2',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      deletedAt: null,
-      itemCategories: [],
-    },
+  const mockDomainCategories: Category[] = [
+    new Category(
+      1,
+      'Category 1',
+      'Description 1',
+      new Date(),
+      new Date(),
+      null
+    ),
+    new Category(
+      2,
+      'Category 2',
+      'Description 2',
+      new Date(),
+      new Date(),
+      null
+    ),
   ];
   const mockTotalCount: number = 2;
-  describe('mapCategories', () => {
-    it('should map categories correctly', (done) => {
-      const builder = new CategoryListOutputBuilder(
-        mockCategories,
-        mockTotalCount
-      );
-      of(mockCategories)
-        .pipe(
-          map((categories) => builder['mapCategories'](categories)) // mapCategoriesを呼び出す
-        )
-        .subscribe((result) => {
-          expect(result).toHaveLength(mockCategories.length);
-          result.forEach((category, index) => {
-            expect(category.id).toBe(mockCategories[index].id);
-            expect(category.name).toBe(mockCategories[index].name);
-            expect(category.description).toBe(
-              mockCategories[index].description
-            );
-            expect(category.createdAt).toBe(mockCategories[index].createdAt);
-            expect(category.updatedAt).toBe(mockCategories[index].updatedAt);
-            expect(category.deletedAt).toBe(mockCategories[index].deletedAt);
-          });
-          done(); // 非同期テストが完了したことを通知
-        });
-    });
-  });
 
   describe('build', () => {
     it('CategoryListOutputDtoを返す', () => {
       const builder = new CategoryListOutputBuilder(
-        mockCategories,
+        mockDomainCategories,
         mockTotalCount
       );
       const result = builder.build();
       expect(result).toBeInstanceOf(CategoryListOutputDto);
-      expect(result).toEqual({
-        count: mockTotalCount,
-        categories: mockCategories.map((category) => ({
-          id: category.id,
-          name: category.name,
-          description: category.description,
-          createdAt: category.createdAt,
-          updatedAt: category.updatedAt,
-        })),
+      expect(result.count).toBe(mockTotalCount);
+      expect(result.categories).toHaveLength(mockDomainCategories.length);
+      mockDomainCategories.forEach((category, index) => {
+        expect(result.categories[index].id).toBe(category.id);
+        expect(result.categories[index].name).toBe(category.name);
+        expect(result.categories[index].description).toBe(category.description);
+        expect(result.categories[index].createdAt).toBe(category.createdAt);
+        expect(result.categories[index].updatedAt).toBe(category.updatedAt);
       });
     });
-  });
-  it('categoriesが空の場合、404エラーを返す', () => {
-    const mockTotalCount = 0;
-    const builder = new CategoryListOutputBuilder([], mockTotalCount);
-    expect(() => builder.build()).toThrow(
-      new HttpException('Categories not found', HttpStatus.NOT_FOUND)
-    );
+
+    it('categoriesが空の場合、404エラーを返す', () => {
+      const mockTotalCount = 0;
+      const builder = new CategoryListOutputBuilder([], mockTotalCount);
+      expect(() => builder.build()).toThrow(
+        new HttpException('Categories not found', HttpStatus.NOT_FOUND)
+      );
+    });
   });
 });

--- a/src/application/dto/output/category/category.list.output.builder.ts
+++ b/src/application/dto/output/category/category.list.output.builder.ts
@@ -1,6 +1,5 @@
 import { OutputBuilder } from '../../output/output.builder';
 import { CategoryListOutputDto } from './category.list.output.dto';
-import { Categories } from '../../../../infrastructure/orm/entities/categories.entity';
 import { Category } from '../../../../domain/inventory/items/entities/category.entity';
 import { NotFoundException } from '@nestjs/common';
 
@@ -10,22 +9,9 @@ export class CategoryListOutputBuilder
   private _totalCount: number;
   private _categories: Category[];
 
-  constructor(categories?: Categories[], totalCount?: number) {
-    this._totalCount = totalCount ?? 0;
-    this._categories = categories ? this.mapCategories(categories) : [];
-  }
-
-  private mapCategories(categories: Categories[]): Category[] {
-    return categories.map((category) => {
-      return new Category(
-        category.id,
-        category.name,
-        category.description,
-        category.createdAt,
-        category.updatedAt,
-        category.deletedAt
-      );
-    });
+  constructor(categories: Category[], totalCount: number) {
+    this._totalCount = totalCount;
+    this._categories = categories;
   }
 
   build(): CategoryListOutputDto {

--- a/src/domain/inventory/items/factories/category.domain.factory.ts
+++ b/src/domain/inventory/items/factories/category.domain.factory.ts
@@ -12,4 +12,8 @@ export class CategoryDomainFactory {
       categories.deletedAt
     );
   }
+
+  static fromInfrastructureList(categories: Categories[]): Category[] {
+    return categories.map((category) => this.fromInfrastructure(category));
+  }
 }

--- a/src/presentation/controllers/category/category.controller.spec.ts
+++ b/src/presentation/controllers/category/category.controller.spec.ts
@@ -138,6 +138,32 @@ describe('CategoryController', () => {
       });
     });
 
+    it('ページ番号に該当するカテゴリ情報が見つからなかった場合、404エラーを返す', (done) => {
+      const input: CategoryListInputDto = {
+        pages: 1,
+      };
+      jest
+        .spyOn(categoryListService, 'service')
+        .mockReturnValue(
+          throwError(() => new NotFoundException('Category not found'))
+        );
+      controller.findCategoryList(input).subscribe({
+        next: () => {
+          done.fail('Expected an error, but got a result');
+        },
+        error: (error) => {
+          expect(error).toBeInstanceOf(NotFoundException);
+          expect(error.message).toBe('Category not found');
+          expect(error.response.statusCode).toBe(404);
+          expect(categoryListService.service).toHaveBeenCalledWith(input);
+          done();
+        },
+        complete: () => {
+          done();
+        },
+      });
+    });
+
     it('pagesが不正の値の場合、400エラーを返す', (done) => {
       const input: CategoryListInputDto = {
         pages: -1,


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- builderファイルでドメインオブジェクトを生成をしていたので、責務が明確になっていない

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- factoryの導入
- builderの修正
- UTの修正
# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
- 確認済み

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
```
npm run start:dev
```
## 動作したときのスクリーンショット
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 動作検証のlog
```
[Nest] 93860  - 2025/03/23 13:46:13     LOG [LoggerInterceptor.name] Request: [GET] /categories?pages=1
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt FROM `categories` `categories` WHERE ( `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) ORDER BY `categories`.`id` ASC LIMIT 10
[Nest] 93860  - 2025/03/23 13:46:13     LOG [LoggerInterceptor.name] Response: [GET] /categories?pages=1 11ms - {"count":10,"categories":[{"id":1,"name":"その他","description":"その他のカテゴリ","createdAt":"2025-01-02T10:13:59.000Z","updatedAt":"2025-01-02T10:13:59.000Z"},{"id":2,"name":"家具","description":"家具に関するカテゴリ","createdAt":"2025-01-02T10:13:59.000Z","updatedAt":"2025-01-02T10:13:59.000Z"},{"id":3,"name":"ガジェット","description":"ガジェットに関するカテゴリ","createdAt":"2025-01-02T10:13:59.000Z","updatedAt":"2025-01-02T10:13:59.000Z"},{"id":4,"name":"書籍","description":"書籍に関するカテゴリ","createdAt":"2025-01-02T10:13:59.000Z","updatedAt":"2025-01-02T10:13:59.000Z"},{"id":5,"name":"日用品","description":"日用品に関するカテゴリ","createdAt":"2025-03-01T07:51:32.000Z","updatedAt":"2025-03-09T07:13:17.000Z"},{"id":6,"name":"衣類","description":"衣類に関するカテゴリ","createdAt":"2025-03-01T09:08:46.000Z","updatedAt":"2025-03-09T07:25:17.000Z"},{"id":7,"name":"huga2","description":"カテゴリーの説明2","createdAt":"2025-03-01T09:24:15.000Z","updatedAt":"2025-03-01T09:24:15.000Z"},{"id":8,"name":"huga3","description":"カテゴリーの説明","createdAt":"2025-03-01T09:28:33.000Z","updatedAt":"2025-03-01T09:28:33.000Z"},{"id":9,"name":"huga4","description":"カテゴリーの説明","createdAt":"2025-03-01T09:29:48.000Z","updatedAt":"2025-03-01T09:29:48.000Z"},{"id":10,"name":"huga5","description":"カテゴリーの説明","createdAt":"2025-03-01T09:30:53.000Z","updatedAt":"2025-03-01T09:30:53.000Z"}]}
[Nest] 93860  - 2025/03/23 13:46:17     LOG [LoggerInterceptor.name] Request: [GET] /categories?pages=2
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt FROM `categories` `categories` WHERE ( `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) ORDER BY `categories`.`id` ASC LIMIT 10 OFFSET 10
[Nest] 93860  - 2025/03/23 13:46:17     LOG [LoggerInterceptor.name] Response: [GET] /categories?pages=2 7ms - {"count":4,"categories":[{"id":11,"name":"huga6","description":"カテゴリーの説明","createdAt":"2025-03-01T11:42:39.000Z","updatedAt":"2025-03-01T11:42:39.000Z"},{"id":12,"name":"huga7","description":"カテゴリーの説明","createdAt":"2025-03-01T12:04:37.000Z","updatedAt":"2025-03-01T12:04:37.000Z"},{"id":13,"name":"huga8","description":"カテゴリーの説明","createdAt":"2025-03-01T14:16:23.000Z","updatedAt":"2025-03-01T14:16:23.000Z"},{"id":14,"name":"huga9","description":"カテゴリーの説明","createdAt":"2025-03-01T14:19:50.000Z","updatedAt":"2025-03-01T14:19:50.000Z"}]}

```
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->