### PR TITLE
fix：物品に紐づくカテゴリを更新できない部分の修正

### DIFF
--- a/src/application/dto/input/item/item.update.input.dto.ts
+++ b/src/application/dto/input/item/item.update.input.dto.ts
@@ -9,13 +9,13 @@ import {
   Min,
   Max,
   IsArray,
-  ArrayUnique,
 } from 'class-validator';
 
 const ITEM_NAME_MIN_LENGTH: number = 1;
 const ITEM_NAME_MAX_LENGTH: number = 255;
 const ITEM_QUANTITY_MIN: number = 1;
 const ITEM_QUANTITY_MAX: number = 1000;
+const ITEM_DESCRIPTION_MAX_LENGTH: number = 255;
 
 export class ItemUpdateInputDto implements InputDto {
   @ApiProperty({
@@ -48,7 +48,7 @@ export class ItemUpdateInputDto implements InputDto {
   @IsNotEmpty()
   @IsString()
   @MinLength(ITEM_NAME_MIN_LENGTH)
-  @MaxLength(ITEM_NAME_MAX_LENGTH)
+  @MaxLength(ITEM_DESCRIPTION_MAX_LENGTH)
   description: string;
 
   @ApiProperty({
@@ -58,7 +58,6 @@ export class ItemUpdateInputDto implements InputDto {
   })
   @IsNotEmpty()
   @IsArray()
-  @ArrayUnique()
   @IsInt({ each: true })
   categoryIds: number[];
 }

--- a/src/application/services/item/item.update.service.spec.ts
+++ b/src/application/services/item/item.update.service.spec.ts
@@ -397,55 +397,6 @@ describe('ItemUpdateService', () => {
       });
     });
 
-    it('更新予定の物品名が現在の物品名と重複している場合、409エラーを返す', (done) => {
-      const inputItemId = 1;
-      const itemUpdateInputDto: ItemUpdateInputDto = {
-        name: 'existingItemName',
-        quantity: 11,
-        description: 'updatedItemDescription',
-        categoryIds: [1, 2, 3],
-      };
-      const mockQueryItem: Items = {
-        id: 1,
-        name: 'existingItemName',
-        quantity: 10,
-        description: 'itemDescription',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        deletedAt: null,
-        itemCategories: [],
-      };
-
-      const mockQueryCategoryIds: number[] = [1, 2, 3];
-
-      jest
-        .spyOn(itemsDatasource, 'findItemById')
-        .mockReturnValue(of(mockQueryItem));
-      jest
-        .spyOn(itemsDatasource, 'findCategoryIdsByItemId')
-        .mockReturnValue(of(mockQueryCategoryIds));
-      jest
-        .spyOn(itemsDatasource, 'findItemByName')
-        .mockReturnValue(of(undefined));
-
-      itemUpdateService.service(itemUpdateInputDto, inputItemId).subscribe({
-        next: () => {
-          done.fail('Expected an error, but got a success response');
-        },
-        error: (error) => {
-          expect(error).toBeInstanceOf(ConflictException);
-          expect(error.message).toBe('This value is not unique');
-          expect(itemsDatasource.findItemById).toHaveBeenCalledWith(
-            inputItemId
-          );
-          expect(itemsDatasource.findCategoryIdsByItemId).toHaveBeenCalledWith(
-            inputItemId
-          );
-          done();
-        },
-      });
-    });
-
     it('更新後の物品名が既存の他の物品名と重複している場合、409エラーを返す', (done) => {
       const inputItemId = 1;
       const itemUpdateInputDto: ItemUpdateInputDto = {

--- a/src/application/services/item/item.update.service.ts
+++ b/src/application/services/item/item.update.service.ts
@@ -63,11 +63,11 @@ export class ItemUpdateService implements ItemUpdateServiceInterface {
       switchMap(([items, currentCategoryIds, conflictItem]) => {
         this.validateItemFound(items);
         this.validateCategoryIdsFound(currentCategoryIds);
-        this.validateUniqueItemName(name, items.name);
-        this.validateUniqueOtherItem(
-          name,
-          conflictItem ? conflictItem.name : undefined
-        );
+
+        // conflictItemが存在し、かつ自分自身でない場合のみ重複チェック
+        if (conflictItem && conflictItem.id !== items.id) {
+          this.validateUniqueOtherItem(name, conflictItem.name);
+        }
 
         // 現在のDBにあるItemの情報
         const domainItem: Item = ItemDomainFactory.fromInfrastructureSingle(
@@ -147,20 +147,6 @@ export class ItemUpdateService implements ItemUpdateServiceInterface {
   private validateCategoryIdsFound(categoryIds: number[]): Observable<void> {
     if (!categoryIds) {
       return throwError(() => new NotFoundException('Category IDs not found'));
-    }
-    return of(undefined);
-  }
-
-  //更新後の物品名と現在の物品名との重複チェック
-  private validateUniqueItemName(
-    name: TextAmount,
-    currentName: string
-  ): Observable<void> {
-    const uniqueItemName = Unique.of(name.value(), currentName);
-    if (uniqueItemName.isDuplicate(currentName)) {
-      return throwError(
-        () => new ConflictException('This value is not unique')
-      );
     }
     return of(undefined);
   }

--- a/src/domain/inventory/items/entities/item.entity.ts
+++ b/src/domain/inventory/items/entities/item.entity.ts
@@ -96,15 +96,6 @@ export class Item {
       return false;
     }
 
-    //変更がない場合
-    if (
-      name === this._name &&
-      quantity === this._quantity &&
-      description === this._description
-    ) {
-      return false;
-    }
-
     //値オブジェクトを使ったビジネスロジックのチェック
     try {
       Quantity.of(quantity);
@@ -147,11 +138,20 @@ export class Item {
       return null;
     }
 
-    const { addCategoryIds: addIds, deleteCategoryIds: deleteIds } =
-      currentItem.getCategoryDiff(categoryIds);
-    if (addIds.length === 0 && deleteIds.length === 0) {
+    // すべての値が同じ場合（カテゴリも含めて）だけnullを返す
+    const isNameSame = name === currentItem._name;
+    const isQuantitySame = quantity === currentItem._quantity;
+    const isDescriptionSame = description === currentItem._description;
+    const isCategorySame =
+      currentItem._categoryIds.length === categoryIds.length &&
+      currentItem._categoryIds.every((id, idx) => id === categoryIds[idx]);
+
+    if (isNameSame && isQuantitySame && isDescriptionSame && isCategorySame) {
       return null;
     }
+
+    const { addCategoryIds: addIds, deleteCategoryIds: deleteIds } =
+      currentItem.getCategoryDiff(categoryIds);
 
     const updatedCategoryIds = [
       ...currentItem.categoryIds.filter((id) => !deleteIds.includes(id)),

--- a/src/presentation/controllers/item/item.controller.spec.ts
+++ b/src/presentation/controllers/item/item.controller.spec.ts
@@ -905,35 +905,6 @@ describe('ItemController', () => {
       });
     });
 
-    it('更新後の物品名と現在の物品名が同じ場合、409エラーを返す', (done) => {
-      const inputItemId = 1;
-      const input: ItemUpdateInputDto = {
-        name: 'updatedItemName',
-        quantity: 11,
-        description: 'updatedItemDescription',
-        categoryIds: [1, 2, 3],
-      };
-      jest
-        .spyOn(itemUpdateService, 'service')
-        .mockImplementation(() =>
-          throwError(() => new ConflictException('This value is not unique'))
-        );
-      controller.updateItem(inputItemId, input).subscribe({
-        next: () => {
-          fail('Expected 409 error, but received results');
-        },
-        error: (err) => {
-          expect(err).toBeInstanceOf(ConflictException);
-          expect(err.response.statusCode).toBe(409);
-          expect(err.response.message).toBe('This value is not unique');
-          done();
-        },
-        complete: () => {
-          done();
-        },
-      });
-    });
-
     it('更新後の物品名と他の物品名が同じ場合、409エラーを返す', (done) => {
       const inputItemId = 1;
       const input: ItemUpdateInputDto = {


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- 物品の更新のときに、カテゴリの更新が正常通りにできなかった

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- クエリの変更
- 重複チェックのロジック変更

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
- フロントエンドからも確認済み

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

## 動作したときのスクリーンショット
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
<details><summary>成功したときのlog</summary>
<p>

```
[Nest] 84612  - 2025/05/25 16:29:00     LOG [LoggerInterceptor.name] Request: [PATCH] /items/1
[Nest] 84612  - 2025/05/25 16:29:00     LOG [ItemUpdateService] Starting update for item with ID: 1
query: SELECT * FROM `items` `items` WHERE ( `items`.`id` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: SELECT category_id AS `id` FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` = ? ) AND ( `item_categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: SELECT * FROM `items` `items` WHERE ( `items`.`name` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: ["Ergonomic Bronze Bike hoge"]
query: START TRANSACTION
query: UPDATE `items` SET `name` = ?, `quantity` = ?, `description` = ?, `updated_at` = ? WHERE `id` = ? -- PARAMETERS: ["Ergonomic Bronze Bike hoge",41,"New Pants model with 44 GB RAM, 952 GB storage, and fond features","2025-05-25T07:29:00.612Z",1]
query: SAVEPOINT typeorm_1
query: UPDATE `item_categories` SET `updated_at` = ?, `deleted_at` = ? WHERE `item_id` = ? AND `category_id` IN (?) -- PARAMETERS: ["2025-05-25T07:29:00.618Z","2025-05-25T07:29:00.618Z",1,[2]]
query: SELECT `item_categories`.`category_id` AS `categoryId` FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` = ? AND `item_categories`.`deleted_at` IS NULL ) AND ( `item_categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: RELEASE SAVEPOINT typeorm_1
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt, `categories`.`deleted_at` AS deletedAt FROM `categories` `categories` WHERE ( `categories`.`id` IN (?, ?) AND `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1,3]
[Nest] 84612  - 2025/05/25 16:29:00     LOG [LoggerInterceptor.name] Response: [PATCH] /items/1 41ms - {"id":1,"name":"Ergonomic Bronze Bike hoge","quantity":41,"description":"New Pants model with 44 GB RAM, 952 GB storage, and fond features","updatedAt":"2025-05-25T07:29:00.610Z","itemCategories":[{"id":1,"name":"書籍","description":"書籍に関するカテゴリ"},{"id":3,"name":"その他","description":"その他のカテゴリ"}]}
query: COMMIT
[Nest] 84612  - 2025/05/25 16:29:00     LOG [LoggerInterceptor.name] Request: [GET] /items/1
query: SELECT * FROM `items` `items` WHERE ( `items`.`id` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt, `categories`.`deleted_at` AS deletedAt FROM `categories` `categories` INNER JOIN `item_categories` `item_categories` ON  `categories`.`id` = `item_categories`.`category_id` AND `item_categories`.`deleted_at` IS NULL WHERE ( `item_categories`.`item_id` = ? AND `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
[Nest] 84612  - 2025/05/25 16:29:00     LOG [LoggerInterceptor.name] Response: [GET] /items/1 8ms - {"id":1,"name":"Ergonomic Bronze Bike hoge","quantity":41,"description":"New Pants model with 44 GB RAM, 952 GB storage, and fond features","itemCategories":[{"id":1,"name":"書籍","description":"書籍に関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":3,"name":"その他","description":"その他のカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"}]}
[Nest] 84612  - 2025/05/25 16:29:03     LOG [LoggerInterceptor.name] Request: [GET] /categories?pages=1
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt FROM `categories` `categories` WHERE ( `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) ORDER BY `categories`.`id` ASC LIMIT 10
[Nest] 84612  - 2025/05/25 16:29:03     LOG [LoggerInterceptor.name] Response: [GET] /categories?pages=1 16ms - {"count":5,"categories":[{"id":1,"name":"書籍","description":"書籍に関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":2,"name":"ガジェット","description":"ガジェットに関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":3,"name":"その他","description":"その他のカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":4,"name":"家具","description":"家具に関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":5,"name":"調理道具","description":"料理などで利用するもの","createdAt":"2025-05-17T22:48:08.000Z","updatedAt":"2025-05-17T22:48:08.000Z"}]}
[Nest] 84612  - 2025/05/25 16:29:07     LOG [LoggerInterceptor.name] Request: [PATCH] /items/1
[Nest] 84612  - 2025/05/25 16:29:07     LOG [ItemUpdateService] Starting update for item with ID: 1
query: SELECT * FROM `items` `items` WHERE ( `items`.`id` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: SELECT category_id AS `id` FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` = ? ) AND ( `item_categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: SELECT * FROM `items` `items` WHERE ( `items`.`name` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: ["Ergonomic Bronze Bike hoge"]
query: START TRANSACTION
query: UPDATE `items` SET `name` = ?, `quantity` = ?, `description` = ?, `updated_at` = ? WHERE `id` = ? -- PARAMETERS: ["Ergonomic Bronze Bike hoge",41,"New Pants model with 44 GB RAM, 952 GB storage, and fond features","2025-05-25T07:29:07.034Z",1]
query: SAVEPOINT typeorm_1
query: UPDATE `item_categories` SET `updated_at` = ?, `deleted_at` = ? WHERE `item_id` = ? AND `category_id` IN (?) -- PARAMETERS: ["2025-05-25T07:29:07.039Z","2025-05-25T07:29:07.039Z",1,[3]]
query: SELECT `item_categories`.`category_id` AS `categoryId` FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` = ? AND `item_categories`.`deleted_at` IS NULL ) AND ( `item_categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: RELEASE SAVEPOINT typeorm_1
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt, `categories`.`deleted_at` AS deletedAt FROM `categories` `categories` WHERE ( `categories`.`id` IN (?) AND `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
[Nest] 84612  - 2025/05/25 16:29:07     LOG [LoggerInterceptor.name] Response: [PATCH] /items/1 24ms - {"id":1,"name":"Ergonomic Bronze Bike hoge","quantity":41,"description":"New Pants model with 44 GB RAM, 952 GB storage, and fond features","updatedAt":"2025-05-25T07:29:07.032Z","itemCategories":[{"id":1,"name":"書籍","description":"書籍に関するカテゴリ"}]}
query: COMMIT
[Nest] 84612  - 2025/05/25 16:29:07     LOG [LoggerInterceptor.name] Request: [GET] /items/1
query: SELECT * FROM `items` `items` WHERE ( `items`.`id` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt, `categories`.`deleted_at` AS deletedAt FROM `categories` `categories` INNER JOIN `item_categories` `item_categories` ON  `categories`.`id` = `item_categories`.`category_id` AND `item_categories`.`deleted_at` IS NULL WHERE ( `item_categories`.`item_id` = ? AND `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
[Nest] 84612  - 2025/05/25 16:29:07     LOG [LoggerInterceptor.name] Response: [GET] /items/1 8ms - {"id":1,"name":"Ergonomic Bronze Bike hoge","quantity":41,"description":"New Pants model with 44 GB RAM, 952 GB storage, and fond features","itemCategories":[{"id":1,"name":"書籍","description":"書籍に関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"}]}
[Nest] 84612  - 2025/05/25 16:29:08     LOG [LoggerInterceptor.name] Request: [GET] /categories?pages=1
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt FROM `categories` `categories` WHERE ( `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) ORDER BY `categories`.`id` ASC LIMIT 10
[Nest] 84612  - 2025/05/25 16:29:08     LOG [LoggerInterceptor.name] Response: [GET] /categories?pages=1 4ms - {"count":5,"categories":[{"id":1,"name":"書籍","description":"書籍に関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":2,"name":"ガジェット","description":"ガジェットに関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":3,"name":"その他","description":"その他のカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":4,"name":"家具","description":"家具に関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":5,"name":"調理道具","description":"料理などで利用するもの","createdAt":"2025-05-17T22:48:08.000Z","updatedAt":"2025-05-17T22:48:08.000Z"}]}
[Nest] 84612  - 2025/05/25 16:29:12     LOG [LoggerInterceptor.name] Request: [PATCH] /items/1
[Nest] 84612  - 2025/05/25 16:29:12     LOG [ItemUpdateService] Starting update for item with ID: 1
query: SELECT * FROM `items` `items` WHERE ( `items`.`id` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: SELECT category_id AS `id` FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` = ? ) AND ( `item_categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: SELECT * FROM `items` `items` WHERE ( `items`.`name` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: ["Ergonomic Bronze Bike hoge"]
query: START TRANSACTION
query: UPDATE `items` SET `name` = ?, `quantity` = ?, `description` = ?, `updated_at` = ? WHERE `id` = ? -- PARAMETERS: ["Ergonomic Bronze Bike hoge",41,"New Pants model with 44 GB RAM, 952 GB storage, and fond features","2025-05-25T07:29:12.093Z",1]
query: SAVEPOINT typeorm_1
query: SELECT `ic`.`id` AS `ic_id`, `ic`.`created_at` AS `ic_created_at`, `ic`.`updated_at` AS `ic_updated_at`, `ic`.`deleted_at` AS `ic_deleted_at`, `ic`.`item_id` AS `ic_item_id`, `ic`.`category_id` AS `ic_category_id`, `category`.`id` AS `category_id`, `category`.`name` AS `category_name`, `category`.`description` AS `category_description`, `category`.`created_at` AS `category_created_at`, `category`.`updated_at` AS `category_updated_at`, `category`.`deleted_at` AS `category_deleted_at` FROM `item_categories` `ic` LEFT JOIN `categories` `category` ON `category`.`id`=`ic`.`category_id` AND (`category`.`deleted_at` IS NULL) WHERE `ic`.`item_id` = ? AND `ic`.`category_id` IN (?) -- PARAMETERS: [1,[2,3,4]]
query: UPDATE `item_categories` SET `deleted_at` = ?, `updated_at` = ? WHERE `item_id` = ? AND `category_id` IN (?) -- PARAMETERS: [null,"2025-05-25T07:29:12.103Z",1,[2,3]]
query: INSERT INTO `item_categories`(`id`, `created_at`, `updated_at`, `deleted_at`, `item_id`, `category_id`) VALUES (DEFAULT, ?, ?, DEFAULT, ?, ?) -- PARAMETERS: ["2025-05-25T07:29:12.106Z","2025-05-25T07:29:12.106Z",1,4]
query: SELECT `ItemCategories`.`id` AS `ItemCategories_id`, `ItemCategories`.`deleted_at` AS `ItemCategories_deleted_at` FROM `item_categories` `ItemCategories` WHERE ( `ItemCategories`.`id` = ? ) AND ( `ItemCategories`.`deleted_at` IS NULL ) -- PARAMETERS: [21]
query: SELECT `item_categories`.`category_id` AS `categoryId` FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` = ? AND `item_categories`.`deleted_at` IS NULL ) AND ( `item_categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: RELEASE SAVEPOINT typeorm_1
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt, `categories`.`deleted_at` AS deletedAt FROM `categories` `categories` WHERE ( `categories`.`id` IN (?, ?, ?, ?) AND `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1,2,3,4]
[Nest] 84612  - 2025/05/25 16:29:12     LOG [LoggerInterceptor.name] Response: [PATCH] /items/1 33ms - {"id":1,"name":"Ergonomic Bronze Bike hoge","quantity":41,"description":"New Pants model with 44 GB RAM, 952 GB storage, and fond features","updatedAt":"2025-05-25T07:29:12.092Z","itemCategories":[{"id":1,"name":"書籍","description":"書籍に関するカテゴリ"},{"id":2,"name":"ガジェット","description":"ガジェットに関するカテゴリ"},{"id":3,"name":"その他","description":"その他のカテゴリ"},{"id":4,"name":"家具","description":"家具に関するカテゴリ"}]}
query: COMMIT
[Nest] 84612  - 2025/05/25 16:29:12     LOG [LoggerInterceptor.name] Request: [GET] /items/1
query: SELECT * FROM `items` `items` WHERE ( `items`.`id` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt, `categories`.`deleted_at` AS deletedAt FROM `categories` `categories` INNER JOIN `item_categories` `item_categories` ON  `categories`.`id` = `item_categories`.`category_id` AND `item_categories`.`deleted_at` IS NULL WHERE ( `item_categories`.`item_id` = ? AND `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
[Nest] 84612  - 2025/05/25 16:29:12     LOG [LoggerInterceptor.name] Response: [GET] /items/1 5ms - {"id":1,"name":"Ergonomic Bronze Bike hoge","quantity":41,"description":"New Pants model with 44 GB RAM, 952 GB storage, and fond features","itemCategories":[{"id":1,"name":"書籍","description":"書籍に関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":2,"name":"ガジェット","description":"ガジェットに関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":3,"name":"その他","description":"その他のカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":4,"name":"家具","description":"家具に関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"}]}
[Nest] 84612  - 2025/05/25 16:29:13     LOG [LoggerInterceptor.name] Request: [GET] /categories?pages=1
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt FROM `categories` `categories` WHERE ( `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) ORDER BY `categories`.`id` ASC LIMIT 10
[Nest] 84612  - 2025/05/25 16:29:13     LOG [LoggerInterceptor.name] Response: [GET] /categories?pages=1 4ms - {"count":5,"categories":[{"id":1,"name":"書籍","description":"書籍に関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":2,"name":"ガジェット","description":"ガジェットに関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":3,"name":"その他","description":"その他のカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":4,"name":"家具","description":"家具に関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":5,"name":"調理道具","description":"料理などで利用するもの","createdAt":"2025-05-17T22:48:08.000Z","updatedAt":"2025-05-17T22:48:08.000Z"}]}
[Nest] 84612  - 2025/05/25 16:29:16     LOG [LoggerInterceptor.name] Request: [PATCH] /items/1
[Nest] 84612  - 2025/05/25 16:29:16     LOG [ItemUpdateService] Starting update for item with ID: 1
query: SELECT * FROM `items` `items` WHERE ( `items`.`id` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: SELECT category_id AS `id` FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` = ? ) AND ( `item_categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: SELECT * FROM `items` `items` WHERE ( `items`.`name` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: ["Ergonomic Bronze Bike hoge"]
query: START TRANSACTION
query: UPDATE `items` SET `name` = ?, `quantity` = ?, `description` = ?, `updated_at` = ? WHERE `id` = ? -- PARAMETERS: ["Ergonomic Bronze Bike hoge",41,"New Pants model with 44 GB RAM, 952 GB storage, and fond features","2025-05-25T07:29:16.551Z",1]
query: SAVEPOINT typeorm_1
query: UPDATE `item_categories` SET `updated_at` = ?, `deleted_at` = ? WHERE `item_id` = ? AND `category_id` IN (?) -- PARAMETERS: ["2025-05-25T07:29:16.555Z","2025-05-25T07:29:16.555Z",1,[3,4]]
query: SELECT `item_categories`.`category_id` AS `categoryId` FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` = ? AND `item_categories`.`deleted_at` IS NULL ) AND ( `item_categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: RELEASE SAVEPOINT typeorm_1
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt, `categories`.`deleted_at` AS deletedAt FROM `categories` `categories` WHERE ( `categories`.`id` IN (?, ?) AND `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1,2]
[Nest] 84612  - 2025/05/25 16:29:16     LOG [LoggerInterceptor.name] Response: [PATCH] /items/1 13ms - {"id":1,"name":"Ergonomic Bronze Bike hoge","quantity":41,"description":"New Pants model with 44 GB RAM, 952 GB storage, and fond features","updatedAt":"2025-05-25T07:29:16.550Z","itemCategories":[{"id":1,"name":"書籍","description":"書籍に関するカテゴリ"},{"id":2,"name":"ガジェット","description":"ガジェットに関するカテゴリ"}]}
query: COMMIT
[Nest] 84612  - 2025/05/25 16:29:16     LOG [LoggerInterceptor.name] Request: [GET] /items/1
query: SELECT * FROM `items` `items` WHERE ( `items`.`id` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt, `categories`.`deleted_at` AS deletedAt FROM `categories` `categories` INNER JOIN `item_categories` `item_categories` ON  `categories`.`id` = `item_categories`.`category_id` AND `item_categories`.`deleted_at` IS NULL WHERE ( `item_categories`.`item_id` = ? AND `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
[Nest] 84612  - 2025/05/25 16:29:16     LOG [LoggerInterceptor.name] Response: [GET] /items/1 9ms - {"id":1,"name":"Ergonomic Bronze Bike hoge","quantity":41,"description":"New Pants model with 44 GB RAM, 952 GB storage, and fond features","itemCategories":[{"id":1,"name":"書籍","description":"書籍に関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":2,"name":"ガジェット","description":"ガジェットに関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"}]}
[Nest] 84612  - 2025/05/25 16:29:19     LOG [LoggerInterceptor.name] Request: [GET] /categories?pages=1
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt FROM `categories` `categories` WHERE ( `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) ORDER BY `categories`.`id` ASC LIMIT 10
[Nest] 84612  - 2025/05/25 16:29:19     LOG [LoggerInterceptor.name] Response: [GET] /categories?pages=1 7ms - {"count":5,"categories":[{"id":1,"name":"書籍","description":"書籍に関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":2,"name":"ガジェット","description":"ガジェットに関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":3,"name":"その他","description":"その他のカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":4,"name":"家具","description":"家具に関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"},{"id":5,"name":"調理道具","description":"料理などで利用するもの","createdAt":"2025-05-17T22:48:08.000Z","updatedAt":"2025-05-17T22:48:08.000Z"}]}
```

</p>
</details> 

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->