### PR TITLE
fix：物品を論理削除するエンドポイントの修正

### DIFF
--- a/src/application/services/item/item.delete.service.ts
+++ b/src/application/services/item/item.delete.service.ts
@@ -37,17 +37,18 @@ export class ItemDeleteService implements ItemDeleteServiceInterface {
           );
         }
 
-        //更新日と削除日が一致している場合は、409エラーを返す
-        if (item.deletedAt === item.updatedAt) {
-          throw new ConflictException(
-            `Item with ID ${itemId} is already deleted`
-          );
-        }
-
         const domainItem = ItemDomainFactory.fromInfrastructureSingle(
           item,
           categoryIds
         );
+
+        domainItem.deletedAt
+          ? (() => {
+              throw new ConflictException(
+                `Item with ID ${itemId} is already deleted`
+              );
+            })()
+          : null;
 
         const deletedItem = domainItem.delete();
         return this.itemsDatasource.deletedById(itemId).pipe(


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- フロントエンドからfetchで削除しようとしたら、参照するプロパティが異なっていたので削除できなかった
```
[Nest] 70519  - 2025/06/01 18:53:55     LOG [ItemDeleteService] Starting delete for item with ID: 9
query: SELECT * FROM `items` `items` WHERE ( `items`.`id` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: [9]
query: SELECT category_id AS `id` FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` = ? ) AND ( `item_categories`.`deleted_at` IS NULL ) -- PARAMETERS: [9]
item: {
  id: 9,
  name: 'Bespoke Metal Chips',
  quantity: 20,
  description: 'Experience the indigo brilliance of our Ball, perfect for damaged environments',
  created_at: 2025-04-29T14:08:13.000Z,
  updated_at: 2025-04-29T14:08:13.000Z,
  deleted_at: null
}
item updatedAt: undefined
item deletedAt: undefined
[Nest] 70519  - 2025/06/01 18:53:55   ERROR [LoggerInterceptor.name] Error: [DELETE] /items/9 11ms - Item with ID 9 is already deleted
```

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 削除するときの判定条件で利用するプロパティの変更
# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
- 確認済み

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- サーバーを起動
- フロントから削除を実行

## 動作したときのスクリーンショット
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- フロントからfetchで投げたあとのlog
```
[Nest] 82801  - 2025/06/01 19:03:13     LOG [LoggerInterceptor.name] Response: [DELETE] /items/10 35ms - {"id":10,"name":"Refined Bronze Mouse","quantity":54,"description":"The sleek and shy Ball comes with violet LED lighting for smart functionality","deletedAt":"2025-06-01T10:03:13.538Z"}
[Nest] 82801  - 2025/06/01 19:03:43     LOG [LoggerInterceptor.name] Request: [GET] /items?pages=1&sort_order=1
query: SELECT `items`.`id` AS id, `items`.`name` AS name, `items`.`quantity` AS quantity, `items`.`description` AS description, `items`.`created_at` AS createdAt, `items`.`updated_at` AS updatedAt FROM `items` `items` INNER JOIN (SELECT id FROM `items` `items` WHERE ( `items`.`deleted_at` IS NULL ) AND ( `items`.`deleted_at` IS NULL ) ORDER BY `items`.`id` ASC LIMIT 10) `sub` ON `items`.`id` = sub.id WHERE `items`.`deleted_at` IS NULL ORDER BY `items`.`id` DESC
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `itemCategories`.`item_id` AS itemId, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt FROM `categories` `categories` INNER JOIN `item_categories` `itemCategories` ON `itemCategories`.`category_id`=`categories`.`id` AND (`itemCategories`.`deleted_at` IS NULL)  INNER JOIN `items` `items` ON `items`.`id`=`itemCategories`.`item_id` AND (`items`.`deleted_at` IS NULL) WHERE ( `items`.`id` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) AND `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) -- PARAMETERS: [11,9,8,7,6,5,4,3,2,1]
query: SELECT `item_categories`.`item_id` AS itemId, `item_categories`.`category_id` AS categoryId FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) AND `item_categories`.`deleted_at` IS NULL ) AND ( `item_categories`.`deleted_at` IS NULL ) ORDER BY `item_categories`.`item_id` ASC -- PARAMETERS: [11,9,8,7,6,5,4,3,2,1]
query: SELECT COUNT(`items`.`id`) AS `count` FROM `items` `items` WHERE ( `items`.`deleted_at` IS NULL ) AND ( `items`.`deleted_at` IS NULL )
```
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->