### PR TITLE
feat：削除した物品一覧を取得するエンドポイントの作成

### DIFF
--- a/blue-print/domain-models/domain-model.pu
+++ b/blue-print/domain-models/domain-model.pu
@@ -36,10 +36,23 @@ class Item {
   - itemId: ID
   - name: String
   - quantity: Integer
+  - description: String
+  - category: Category
+  - status: ItemStatus
   + checkAvailability(): Boolean
-  + addItem(name: String, quantity: Integer, category: Category)
-  + editItem(newName: String, newQuantity: Integer, newCategory: Category)
-  + removeItem()
+  + create()
+  + update()
+  + delete() // 論理削除
+  + restore() // 論理削除を復元
+  + purge() // 物理削除
+  + validateUpdate(): Boolean // 更新時のバリデーション
+  + getCategoryDiff(newCategoryIds: number[]): categoryDiff) // 更新時のカテゴリ差分取得
+}
+
+enum ItemStatus {
+  AVAILABLE
+  UNAVAILABLE
+  DELETED
 }
 
 class Category {

--- a/src/application/dto/input/item/deleted.item.list.input.dto.ts
+++ b/src/application/dto/input/item/deleted.item.list.input.dto.ts
@@ -1,0 +1,31 @@
+import { InputDto } from '../input.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { Min, Max, IsOptional } from 'class-validator';
+import { Expose, Transform } from 'class-transformer';
+
+const PAGE_MIN = 1;
+const SORT_ORDER_MIN = 0;
+const SORT_ORDER_MAX = 1;
+
+export class DeletedItemListInputDto implements InputDto {
+  @ApiProperty({
+    example: 1,
+    description: 'ページ番号(1以上の整数とする)',
+    type: Number,
+  })
+  @IsOptional()
+  @Min(PAGE_MIN)
+  pages?: number;
+
+  @ApiProperty({
+    example: 0,
+    description: '並べ替え順 0=昇順, 1=降順',
+    type: Number,
+  })
+  @IsOptional()
+  @Min(SORT_ORDER_MIN)
+  @Max(SORT_ORDER_MAX)
+  @Transform(({ value }) => Number(value))
+  @Expose({ name: 'sort_order' })
+  sortOrder?: number;
+}

--- a/src/application/dto/output/item/deleted.item.list.output.builder.spec.ts
+++ b/src/application/dto/output/item/deleted.item.list.output.builder.spec.ts
@@ -1,0 +1,74 @@
+import { DeletedItemListOutputBuilder } from './deleted.item.list.output.builder';
+import { DeletedItemListOutputDto } from './deleted.item.list.output.dto';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { Item } from '../../../../domain/inventory/items/entities/item.entity';
+import { Category } from '../../../../domain/inventory/items/entities/category.entity';
+
+describe('DeletedItemListOutputBuilder', () => {
+  const mockDomainItems: Item[] = [
+    new Item(1, 'Item 1', 10, 'Description 1', new Date(), new Date(), null, [
+      1,
+    ]),
+    new Item(2, 'Item 2', 5, 'Description 2', new Date(), new Date(), null, [
+      2,
+    ]),
+  ];
+  const mockTotalCount: number = 2;
+  const mockTotalPages: number = 1;
+  const mockDomainCategories: Category[] = [
+    new Category(
+      1,
+      'Category 1',
+      'その他のカテゴリ',
+      new Date(),
+      new Date(),
+      null
+    ),
+    new Category(
+      2,
+      'Category 2',
+      'その他のカテゴリ',
+      new Date(),
+      new Date(),
+      null
+    ),
+  ];
+
+  describe('build', () => {
+    it('DeletedItemListOutputDtoを返す', () => {
+      const builder = new DeletedItemListOutputBuilder(
+        mockDomainItems,
+        mockTotalCount,
+        mockTotalPages,
+        mockDomainCategories
+      );
+
+      const result = builder.build();
+      expect(result).toBeInstanceOf(DeletedItemListOutputDto);
+      expect(result.count).toBe(mockTotalCount);
+      expect(result.totalPages).toBe(mockTotalPages);
+      expect(result.results).toHaveLength(mockDomainItems.length);
+
+      mockDomainItems.forEach((item, index) => {
+        const resultItem = result.results[index];
+
+        expect(resultItem.id).toBe(item.id);
+        expect(resultItem.name).toBe(item.name);
+        expect(resultItem.quantity).toBe(item.quantity);
+        expect(resultItem.description).toBe(item.description);
+        expect(resultItem.createdAt).toEqual(item.createdAt);
+        expect(resultItem.updatedAt).toEqual(item.updatedAt);
+        expect(resultItem.deletedAt).toEqual(item.deletedAt);
+
+        expect(resultItem.itemsCategories).toHaveLength(1); // 1つのカテゴリが紐づいていることを期待
+      });
+    });
+
+    it('アイテムが存在しない場合、NotFoundExceptionをスローする', () => {
+      const emptyBuilder = new DeletedItemListOutputBuilder([], 0, 0, []);
+      expect(() => emptyBuilder.build()).toThrow(
+        new HttpException('Items not found', HttpStatus.NOT_FOUND)
+      );
+    });
+  });
+});

--- a/src/application/dto/output/item/deleted.item.list.output.builder.ts
+++ b/src/application/dto/output/item/deleted.item.list.output.builder.ts
@@ -1,0 +1,67 @@
+import { OutputBuilder } from '../../output/output.builder';
+import {
+  DeletedItemListOutputDto,
+  itemCategories,
+} from './deleted.item.list.output.dto';
+import { Item } from '../../../../domain/inventory/items/entities/item.entity';
+import { Category } from '../../../../domain/inventory/items/entities/category.entity';
+import { NotFoundException } from '@nestjs/common';
+
+export class DeletedItemListOutputBuilder
+  implements OutputBuilder<DeletedItemListOutputDto>
+{
+  private _totalCount: number;
+  private _items: Item[];
+  private _totalPages: number;
+  private _categories: Category[];
+
+  constructor(
+    items: Item[],
+    totalCount: number,
+    totalPage: number,
+    categories: Category[]
+  ) {
+    this._totalCount = totalCount;
+    this._items = items;
+    this._totalPages = totalPage;
+    this._categories = categories;
+  }
+
+  build(): DeletedItemListOutputDto {
+    return this._totalCount === 0
+      ? (() => {
+          throw new NotFoundException('Items not found');
+        })()
+      : (() => {
+          const output = new DeletedItemListOutputDto();
+          output.count = this._totalCount;
+          output.totalPages = this._totalPages;
+          output.results = this._items.map((item) => ({
+            id: item.id,
+            name: item.name,
+            quantity: item.quantity,
+            description: item.description,
+            createdAt: item.createdAt,
+            updatedAt: item.updatedAt,
+            deletedAt: item.deletedAt,
+            itemsCategories: item.categoryIds
+              .map((categoryId) => {
+                const category = this._categories.find(
+                  (cat) => cat.id === categoryId
+                );
+                return category
+                  ? {
+                      id: category.id,
+                      name: category.name,
+                      description: category.description,
+                      createdAt: category.createdAt,
+                      updatedAt: category.updatedAt,
+                    }
+                  : null;
+              })
+              .filter(Boolean) as itemCategories[],
+          }));
+          return output;
+        })();
+  }
+}

--- a/src/application/dto/output/item/deleted.item.list.output.dto.ts
+++ b/src/application/dto/output/item/deleted.item.list.output.dto.ts
@@ -1,0 +1,217 @@
+import 'reflect-metadata';
+import { OutputDto } from '../output.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose, Type } from 'class-transformer';
+
+export class itemCategories {
+  @ApiProperty({
+    example: 1,
+    description: 'カテゴリーID',
+    type: Number,
+  })
+  @Expose({ name: 'id' })
+  id: number;
+
+  @ApiProperty({
+    example: 'テストカテゴリー',
+    description: 'カテゴリー名',
+    type: String,
+  })
+  @Expose({ name: 'name' })
+  name: string;
+
+  @ApiProperty({
+    example: 'このカテゴリーはテスト用です。',
+    description: `
+    カテゴリーの詳細
+    `,
+    type: String,
+  })
+  @Expose({ name: 'description' })
+  description: string;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+    作成日時
+    `,
+    type: String,
+  })
+  @Expose({ name: 'created_at' })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+    更新日時
+    `,
+    type: String,
+  })
+  @Expose({ name: 'updated_at' })
+  updatedAt: Date;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+    削除日時
+    `,
+    type: String,
+  })
+  @Expose({ name: 'deleted_at' })
+  deletedAt: Date;
+}
+
+export class DeletedItemResults {
+  @ApiProperty({
+    example: 1,
+    description: `
+      物品ID
+      `,
+    type: Number,
+  })
+  @Expose({ name: 'id' })
+  id: number;
+
+  @ApiProperty({
+    example: 'テスト物品',
+    description: `
+      物品名
+      `,
+    type: String,
+  })
+  @Expose({ name: 'name' })
+  name: string;
+
+  @ApiProperty({
+    example: 1,
+    description: `
+      物品数
+      `,
+    type: Number,
+  })
+  @Expose({ name: 'quantity' })
+  quantity: number;
+
+  @ApiProperty({
+    example: 'この物品はテスト用です。',
+    description: `
+      物品の詳細
+      `,
+    type: String,
+  })
+  @Expose({ name: 'description' })
+  description: string;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+      作成日時
+      `,
+    type: String,
+  })
+  @Expose({ name: 'created_at' })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+      更新日時
+      `,
+    type: String,
+  })
+  @Expose({ name: 'updated_at' })
+  updatedAt: Date;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+      削除日時
+      `,
+    type: String,
+  })
+  @Expose({ name: 'deleted_at' })
+  deletedAt: Date;
+
+  @ApiProperty({
+    example: 1,
+    description: `
+      カテゴリーID
+      `,
+    type: Number,
+  })
+  @Expose({ name: 'Category' })
+  itemsCategories: itemCategories[];
+}
+
+export class DeletedItemListOutputDto implements OutputDto {
+  //count
+  @ApiProperty({
+    example: 2,
+    description: `
+    論理削除された物品の数
+    `,
+    type: Number,
+  })
+  @Expose({ name: 'count' })
+  count: number;
+
+  //totalPages
+  @ApiProperty({
+    example: 1,
+    description: `
+    総ページ数
+    `,
+    type: Number,
+  })
+  @Expose({ name: 'total_pages' })
+  totalPages: number;
+
+  @ApiProperty({
+    example: 0,
+    description: `
+    並べ替え順
+    0: 昇順(省略された場合はデフォルトとする)
+    1: 降順
+    `,
+    type: Number,
+  })
+  @Expose({ name: 'sort_order' })
+  sortOrder?: number;
+
+  @ApiProperty({
+    example: [
+      {
+        id: 1,
+        name: 'テスト物品',
+        quantity: 1,
+        description: 'この物品はテスト用です。',
+        Category: {
+          id: 1,
+          name: 'テストカテゴリー',
+          description: 'このカテゴリーはテスト用です。',
+          created_at: '2021-01-01T00:00:00.000Z',
+          updated_at: '2021-01-01T00:00:00.000Z',
+          deleted_at: '2021-01-01T00:00:00.000Z',
+        },
+      },
+      {
+        id: 2,
+        name: 'テスト物品2',
+        quantity: 2,
+        description: 'この物品はテスト用2です。',
+        Category: {
+          id: 2,
+          name: 'テストカテゴリー2',
+          description: 'このカテゴリーはテスト用2です。',
+          created_at: '2021-01-02T00:00:00.000Z',
+          updated_at: '2021-01-02T00:00:00.000Z',
+          deleted_at: '2021-01-02T00:00:00.000Z',
+        },
+      },
+    ],
+    type: [DeletedItemResults],
+    description: '論理削除された物品の一覧',
+  })
+  @Type(() => DeletedItemResults)
+  results: DeletedItemResults[];
+}

--- a/src/application/services/item/deleted.item.list.interface.ts
+++ b/src/application/services/item/deleted.item.list.interface.ts
@@ -1,0 +1,14 @@
+import { DeletedItemListInputDto } from '../../dto/input/item/deleted.item.list.input.dto';
+import { DeletedItemListOutputDto } from '../../dto/output/item/deleted.item.list.output.dto';
+import { ApplicationService } from '../application.service';
+import { ItemsDatasource } from '../../../infrastructure/datasources/items/items.datasource';
+import { CategoriesDatasource } from '../../../infrastructure/datasources/categories/categories.datasource';
+
+export interface DeletedItemListServiceInterface
+  extends ApplicationService<
+    DeletedItemListInputDto,
+    DeletedItemListOutputDto
+  > {
+  ItemsDatasource: ItemsDatasource;
+  categoriesDatasource: CategoriesDatasource;
+}

--- a/src/application/services/item/deleted.item.list.service.spec.ts
+++ b/src/application/services/item/deleted.item.list.service.spec.ts
@@ -1,0 +1,272 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { of } from 'rxjs';
+import { DeletedItemListService } from './deleted.item.list.service';
+import { ItemsDatasource } from '../../../infrastructure/datasources/items/items.datasource';
+import { DeletedItemListInputDto } from '../../dto/input/item/deleted.item.list.input.dto';
+import { CategoriesDatasource } from '../../../infrastructure/datasources/categories/categories.datasource';
+import { NotFoundException } from '@nestjs/common';
+import { DeletedItemListOutputDto } from '../../dto/output/item/deleted.item.list.output.dto';
+import { Items } from '../../../infrastructure/orm/entities/items.entity';
+import { Categories } from '../../../infrastructure/orm/entities/categories.entity';
+import { Item } from '../../../domain/inventory/items/entities/item.entity';
+import { Category } from '../../../domain/inventory/items/entities/category.entity';
+import { ItemDomainFactory } from '../../../domain/inventory/items/factories/item.domain.factory';
+import { CategoryDomainFactory } from '../../../domain/inventory/items/factories/category.domain.factory';
+
+describe('DeletedItemListService', () => {
+  let deletedItemListService: DeletedItemListService;
+  let itemsDatasource: ItemsDatasource;
+  let categoriesDatasource: CategoriesDatasource;
+
+  const mockItemDomainFactory = {
+    fromInfrastructure: jest.fn(),
+  };
+  const mockCategoryDomainFactory = {
+    fromInfrastructure: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeletedItemListService,
+        {
+          provide: ItemsDatasource,
+          useValue: {
+            findDeletedItemList: jest.fn(),
+            countDeletedAll: jest.fn(),
+          },
+        },
+        {
+          provide: CategoriesDatasource,
+          useValue: {
+            findByCategories: jest.fn(),
+            findCategoryIdsAndItemIds: jest.fn(),
+          },
+        },
+        {
+          provide: ItemDomainFactory,
+          useValue: mockItemDomainFactory,
+        },
+        {
+          provide: CategoryDomainFactory,
+          useValue: mockCategoryDomainFactory,
+        },
+      ],
+    }).compile();
+
+    deletedItemListService = module.get<DeletedItemListService>(
+      DeletedItemListService
+    );
+    itemsDatasource = module.get<ItemsDatasource>(ItemsDatasource);
+    categoriesDatasource =
+      module.get<CategoriesDatasource>(CategoriesDatasource);
+  });
+
+  it('should be defined', () => {
+    expect(deletedItemListService).toBeDefined();
+  });
+
+  describe('service', () => {
+    it('論理削除されている物品一覧を取得する', (done) => {
+      const input: DeletedItemListInputDto = {
+        pages: 1,
+        sortOrder: 0,
+      };
+      const mockDeletedItems: Items[] = [
+        {
+          id: 1,
+          name: 'Deleted Item 1',
+          quantity: 10,
+          description: 'Description 1',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          deletedAt: new Date(),
+          itemCategories: [],
+        },
+        {
+          id: 2,
+          name: 'Deleted Item 2',
+          quantity: 5,
+          description: 'Description 2',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          deletedAt: new Date(),
+          itemCategories: [],
+        },
+      ];
+      const mockCategories: Categories[] = [
+        {
+          id: 1,
+          name: 'Category 1',
+          description: 'categoryDescription',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          deletedAt: null,
+          itemCategories: [],
+        },
+        {
+          id: 2,
+          name: 'Category 2',
+          description: 'categoryDescription',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          deletedAt: null,
+          itemCategories: [],
+        },
+      ];
+      const mockCategoryIdsAndItemIds = [
+        { itemId: 1, categoryId: 1 },
+        { itemId: 2, categoryId: 2 },
+      ];
+
+      const mockTotalItemCount: number = 2;
+      const mockTotalPages: number = 1;
+
+      const mockDomainDeletedItems: Item[] = [
+        new Item(
+          1,
+          'Deleted Item 1',
+          10,
+          'Description 1',
+          new Date(),
+          new Date(),
+          new Date(),
+          [1]
+        ),
+        new Item(
+          2,
+          'Deleted Item 2',
+          5,
+          'Description 2',
+          new Date(),
+          new Date(),
+          new Date(),
+          [2]
+        ),
+      ];
+
+      const mockDomainCategories: Category[] = [
+        new Category(
+          1,
+          'Category 1',
+          'categoryDescription',
+          new Date(),
+          new Date(),
+          null
+        ),
+        new Category(
+          2,
+          'Category 2',
+          'categoryDescription',
+          new Date(),
+          new Date(),
+          null
+        ),
+      ];
+
+      jest
+        .spyOn(itemsDatasource, 'findDeletedItemList')
+        .mockReturnValue(of(mockDeletedItems));
+      jest
+        .spyOn(categoriesDatasource, 'findByCategories')
+        .mockReturnValue(of(mockCategories));
+      jest
+        .spyOn(categoriesDatasource, 'findCategoryIdsAndItemIds')
+        .mockReturnValue(of(mockCategoryIdsAndItemIds));
+      jest
+        .spyOn(itemsDatasource, 'countDeletedAll')
+        .mockReturnValue(of(mockTotalItemCount));
+      mockItemDomainFactory.fromInfrastructure.mockImplementation(
+        (item: Items) => {
+          return mockDomainDeletedItems.find(
+            (domainItem) => domainItem.id === item.id
+          );
+        }
+      );
+      mockCategoryDomainFactory.fromInfrastructure.mockImplementation(
+        (category: Categories) => {
+          return mockDomainCategories.find(
+            (domainCategory) => domainCategory.id === category.id
+          );
+        }
+      );
+
+      deletedItemListService.service(input).subscribe({
+        next: (result) => {
+          expect(result).toBeInstanceOf(DeletedItemListOutputDto);
+          expect(result.count).toBe(mockTotalItemCount);
+          expect(result.totalPages).toBe(mockTotalPages);
+          expect(result.results.length).toBe(mockDeletedItems.length);
+
+          result.results.forEach((item, index) => {
+            expect(item.id).toBe(mockDomainDeletedItems[index].id);
+            expect(item.name).toBe(mockDomainDeletedItems[index].name);
+            expect(item.quantity).toBe(mockDomainDeletedItems[index].quantity);
+            expect(item.description).toBe(
+              mockDomainDeletedItems[index].description
+            );
+            expect(item.itemsCategories.length).toBe(1);
+
+            const expectedCategory = mockDomainCategories.find(
+              (cat) => cat.id === item.itemsCategories[0].id
+            );
+            expect(expectedCategory).toBeDefined();
+            expect(item.itemsCategories[0].id).toBe(expectedCategory.id);
+            expect(item.itemsCategories[0].name).toBe(expectedCategory.name);
+            expect(item.itemsCategories[0].description).toBe(
+              expectedCategory.description
+            );
+          });
+        },
+        error: (err) => {
+          done.fail(err);
+        },
+        complete: () => {
+          done();
+        },
+      });
+    });
+
+    it('論理削除されている物品が存在しない場合、404エラーをスローする', (done) => {
+      const mockDeletedItems: Items[] = [];
+      const mockCategories: Categories[] = [];
+      const mockCategoryIdsAndItemIds = [];
+
+      const mockTotalItemCount: number = 0;
+
+      jest
+        .spyOn(itemsDatasource, 'findDeletedItemList')
+        .mockReturnValue(of(mockDeletedItems));
+      jest
+        .spyOn(categoriesDatasource, 'findByCategories')
+        .mockReturnValue(of(mockCategories));
+      jest
+        .spyOn(categoriesDatasource, 'findCategoryIdsAndItemIds')
+        .mockReturnValue(of(mockCategoryIdsAndItemIds));
+      jest
+        .spyOn(itemsDatasource, 'countDeletedAll')
+        .mockReturnValue(of(mockTotalItemCount));
+      mockItemDomainFactory.fromInfrastructure.mockImplementation(() => {
+        return null;
+      });
+      mockCategoryDomainFactory.fromInfrastructure.mockImplementation(() => {
+        return null;
+      });
+
+      deletedItemListService.service({ pages: 1, sortOrder: 0 }).subscribe({
+        next: () => {
+          done.fail('Expected an error, but got a result');
+        },
+        error: (err) => {
+          expect(err).toBeInstanceOf(Error);
+          expect(err).toBeInstanceOf(NotFoundException);
+          expect(err.message).toBe('Items not found');
+          done();
+        },
+        complete: () => {
+          done.fail('Expected an error, but completed successfully');
+        },
+      });
+    });
+  });
+});

--- a/src/application/services/item/deleted.item.list.service.ts
+++ b/src/application/services/item/deleted.item.list.service.ts
@@ -1,0 +1,68 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { DeletedItemListServiceInterface } from './deleted.item.list.interface';
+import { Observable, forkJoin, map, of, switchMap, throwError } from 'rxjs';
+import { DeletedItemListInputDto } from '../../dto/input/item/deleted.item.list.input.dto';
+import { DeletedItemListOutputDto } from '../../dto/output/item/deleted.item.list.output.dto';
+import { ItemsDatasource } from '../../../infrastructure/datasources/items/items.datasource';
+import { CategoriesDatasource } from '../../../infrastructure/datasources/categories/categories.datasource';
+import { DeletedItemListOutputBuilder } from '../../dto/output/item/deleted.item.list.output.builder';
+import { ItemDomainFactory } from '../../../domain/inventory/items/factories/item.domain.factory';
+import { CategoryDomainFactory } from '../../../domain/inventory/items/factories/category.domain.factory';
+import { Pagination } from '../../../domain/common/value-objects/pagination';
+import { SortOrder } from '../../../domain/common/value-objects/sort/sort.order';
+
+@Injectable()
+export class DeletedItemListService implements DeletedItemListServiceInterface {
+  // 登録されている物品情報に関するコンストラクタ
+  constructor(
+    public readonly ItemsDatasource: ItemsDatasource,
+    public readonly categoriesDatasource: CategoriesDatasource
+  ) {}
+
+  /**
+   * 論理削除されている物品の一覧を取得する
+   * @param {DeletedItemListInputDto} input - リクエスト情報
+   * @returns {Observable<DeletedItemListOutputDto>} - 論理削除されている物品の一覧情報を含むObservableオブジェクト
+   *
+   * @throws {NotFoundException} 物品が見つからない場合、404エラーをスローします。
+   */
+
+  service(
+    input: DeletedItemListInputDto
+  ): Observable<DeletedItemListOutputDto> {
+    const pagination = Pagination.of(input.pages);
+    const sortOrder = SortOrder.of(input.sortOrder);
+
+    return this.ItemsDatasource.findDeletedItemList(pagination, sortOrder).pipe(
+      switchMap((deletedItems) => {
+        if (deletedItems.length === 0) {
+          return throwError(() => new NotFoundException('Items not found'));
+        }
+        const itemIds = deletedItems.map((item) => item.id);
+        return forkJoin([
+          this.categoriesDatasource.findByCategories(itemIds),
+          this.categoriesDatasource.findCategoryIdsAndItemIds(itemIds),
+          of(deletedItems),
+          this.ItemsDatasource.countDeletedAll(),
+        ]);
+      }),
+      map(
+        ([categories, itemIdsAndCategoryIds, deletedItems, totalItemCount]) => {
+          const totalCount = deletedItems.length;
+          const deletedDomainItems = deletedItems.map((item) =>
+            ItemDomainFactory.fromInfrastructure(item, itemIdsAndCategoryIds)
+          );
+          const domainCategories = categories.map((category) =>
+            CategoryDomainFactory.fromInfrastructure(category)
+          );
+          return new DeletedItemListOutputBuilder(
+            deletedDomainItems,
+            totalCount,
+            pagination.calcTotalPages(totalItemCount),
+            domainCategories
+          ).build();
+        }
+      )
+    );
+  }
+}

--- a/src/presentation/controllers/item/item.controller.ts
+++ b/src/presentation/controllers/item/item.controller.ts
@@ -15,6 +15,7 @@ import { ItemRegisterServiceInterface } from '../../../application/services/item
 import { ItemUpdateServiceInterface } from '../../../application/services/item/item.update.interface';
 import { ItemDeleteServiceInterface } from '../../../application/services/item/item.delete.interface';
 import { ItemSingleServiceInterface } from '../../../application/services/item/item.single.interface';
+import { DeletedItemListServiceInterface } from '../../../application/services/item/deleted.item.list.interface';
 import { Observable } from 'rxjs';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ItemListInputDto } from '../../../application/dto/input/item/item.list.input.dto';
@@ -27,6 +28,8 @@ import { ItemDeleteInputDto } from '../../../application/dto/input/item/item.del
 import { ItemDeleteOutputDto } from '../../../application/dto/output/item/item.delete.output.dto';
 import { ItemSingleInputDto } from '../../../application/dto/input/item/item.single.input.dto';
 import { ItemSingleOutputDto } from '../../../application/dto/output/item/item.single.output.dto';
+import { DeletedItemListInputDto } from '../../../application/dto/input/item/deleted.item.list.input.dto';
+import { DeletedItemListOutputDto } from '../../../application/dto/output/item/deleted.item.list.output.dto';
 
 @ApiTags('items')
 @Controller('items')
@@ -41,7 +44,9 @@ export class ItemController {
     @Inject('ItemDeleteServiceInterface')
     private readonly ItemDeleteService: ItemDeleteServiceInterface,
     @Inject('ItemSingleServiceInterface')
-    private readonly ItemSingleService: ItemSingleServiceInterface
+    private readonly ItemSingleService: ItemSingleServiceInterface,
+    @Inject('DeletedItemListServiceInterface')
+    private readonly DeletedItemListService: DeletedItemListServiceInterface
   ) {}
 
   /**
@@ -63,6 +68,26 @@ export class ItemController {
     @Query() query: ItemListInputDto
   ): Observable<ItemListOutputDto> {
     return this.ItemListService.service(query);
+  }
+
+  /**
+   * @param query - クエリ情報
+   * @return {Observable<DeletedItemListOutputDto>} - 削除された物品の一覧情報を含むObservable
+   */
+  @ApiOperation({
+    summary: '削除された物品の一覧を返すエンドポイント',
+    description: '削除された物品の一覧を返すAPI',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'OK',
+    type: DeletedItemListOutputDto,
+  })
+  @Get('deleted')
+  findDeletedItemList(
+    @Query() query: DeletedItemListInputDto
+  ): Observable<DeletedItemListOutputDto> {
+    return this.DeletedItemListService.service(query);
   }
 
   /**

--- a/src/presentation/modules/items.module.ts
+++ b/src/presentation/modules/items.module.ts
@@ -6,6 +6,7 @@ import { ItemRegisterService } from '../../application/services/item/item.regist
 import { ItemUpdateService } from '../../application/services/item/item.update.service';
 import { ItemDeleteService } from '../../application/services/item/item.delete.service';
 import { ItemSingleService } from '../../application/services/item/item.single.service';
+import { DeletedItemListService } from '../../application/services/item/deleted.item.list.service';
 import { DatabaseModule } from './database.module';
 import { ItemsDatasource } from 'src/infrastructure/datasources/items/items.datasource';
 import { CategoriesModule } from './categories.module';
@@ -40,6 +41,10 @@ import { RabbitMQModule } from './rabbitmq.module';
     {
       provide: 'ItemSingleServiceInterface',
       useClass: ItemSingleService,
+    },
+    {
+      provide: 'DeletedItemListServiceInterface',
+      useClass: DeletedItemListService,
     },
   ],
 })


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#69 
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- controllerにエンドポイントを追加
- I/Oの作成
- クエリの作成
- アプリケーションサービスの作成
- 単体テストの作成
- APIドキュメントに追加

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

## 動作したときのスクリーンショット
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
```
 curl "http://localhost:4000/items/deleted?pages=1&sort_order=0"


[Nest] 60475  - 2025/06/08 4:01:09     LOG [LoggerInterceptor.name] Request: [GET] /items/deleted?pages=1&sort_order=0
query: SELECT `items`.`id` AS id, `items`.`name` AS name, `items`.`quantity` AS quantity, `items`.`description` AS description, `items`.`created_at` AS createdAt, `items`.`updated_at` AS updatedAt, `items`.`deleted_at` AS deletedAt FROM `items` `items` INNER JOIN (SELECT `items_sub`.`id` AS `id` FROM `items` `items_sub` WHERE `items_sub`.`deleted_at` IS NOT NULL ORDER BY `items_sub`.`id` ASC LIMIT 10) `sub` ON `items`.`id` = sub.id WHERE `items`.`deleted_at` IS NOT NULL ORDER BY `items`.`id` ASC
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `itemCategories`.`item_id` AS itemId, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt FROM `categories` `categories` INNER JOIN `item_categories` `itemCategories` ON `itemCategories`.`category_id`=`categories`.`id` AND (`itemCategories`.`deleted_at` IS NULL)  INNER JOIN `items` `items` ON `items`.`id`=`itemCategories`.`item_id` AND (`items`.`deleted_at` IS NULL) WHERE ( `items`.`id` IN (?, ?, ?, ?, ?) AND `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) -- PARAMETERS: [10,11,12,13,14]
query: SELECT COUNT(`items`.`id`) AS `count` FROM `items` `items` WHERE `items`.`deleted_at` IS NOT NULL
query: SELECT `item_categories`.`item_id` AS itemId, `item_categories`.`category_id` AS categoryId FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` IN (?, ?, ?, ?, ?) AND `item_categories`.`deleted_at` IS NULL ) AND ( `item_categories`.`deleted_at` IS NULL ) ORDER BY `item_categories`.`item_id` ASC -- PARAMETERS: [10,11,12,13,14]
[Nest] 60475  - 2025/06/08 4:01:09     LOG [LoggerInterceptor.name] Response: [GET] /items/deleted?pages=1&sort_order=0 30ms - {"count":5,"totalPages":1,"results":[{"id":10,"name":"Refined Bronze Mouse","quantity":54,"description":"The sleek and shy Ball comes with violet LED lighting for smart functionality","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-06-01T10:03:14.000Z","deletedAt":"2025-06-01T10:03:13.538Z","itemsCategories":[]},{"id":11,"name":"Unbranded Cotton Pizza","quantity":66,"description":"Discover the cow-like agility of our Hat, perfect for lustrous users","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-06-01T10:16:23.000Z","deletedAt":"2025-06-01T10:16:23.241Z","itemsCategories":[]},{"id":12,"name":"Refined Wooden Car","quantity":25,"description":"Discover the gecko-like agility of our Pizza, perfect for agreeable users","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-06-01T10:18:35.000Z","deletedAt":"2025-06-01T10:18:35.182Z","itemsCategories":[]},{"id":13,"name":"Refined Metal Chair","quantity":50,"description":"Savor the fluffy essence in our Shirt, designed for lined culinary adventures","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-06-01T10:21:27.000Z","deletedAt":"2025-06-01T10:21:27.428Z","itemsCategories":[]},{"id":14,"name":"Intelligent Rubber Pants","quantity":49,"description":"Bespoke Pants designed with Bronze for well-made performance","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-06-01T10:22:00.000Z","deletedAt":"2025-06-01T10:22:00.497Z","itemsCategories":[]}]}
```
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->