### PR TITLE
feat：論理削除されている物品を復元するエンドポイントの作成

### DIFF
--- a/src/application/dto/input/item/item.restore.input.dto.ts
+++ b/src/application/dto/input/item/item.restore.input.dto.ts
@@ -1,0 +1,17 @@
+import { InputDto } from '../input.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsInt, Min } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class ItemRestoreInputDto implements InputDto {
+  @ApiProperty({
+    example: '1',
+    description: '物品ID',
+    type: String,
+  })
+  @IsNotEmpty()
+  @IsInt()
+  @Min(1)
+  @Transform(({ value }) => parseInt(value))
+  id: number;
+}

--- a/src/application/dto/output/item/item.restore.output.builder.spec.ts
+++ b/src/application/dto/output/item/item.restore.output.builder.spec.ts
@@ -1,0 +1,32 @@
+import { ItemRestoreOutputBuilder } from './item.restore.output.builder';
+import { ItemRestoreOutputDto } from './item.restore.output.dto'; // 修正
+import { Item } from '../../../../domain/inventory/items/entities/item.entity';
+
+describe('ItemRestoreOutputBuilder', () => {
+  const mockDomainItem: Item = new Item(
+    1,
+    'Item 1',
+    10,
+    'Description 1',
+    new Date(),
+    new Date(),
+    new Date(),
+    [1]
+  );
+
+  describe('build', () => {
+    it('should return ItemRestoreOutputDto', () => {
+      const builder = new ItemRestoreOutputBuilder(mockDomainItem);
+      const result = builder.build();
+
+      expect(result).toBeInstanceOf(ItemRestoreOutputDto); // 修正
+      expect(result.id).toBe(mockDomainItem.id);
+      expect(result.name).toBe(mockDomainItem.name);
+      expect(result.quantity).toBe(mockDomainItem.quantity);
+      expect(result.description).toBe(mockDomainItem.description);
+      expect(result.createdAt).toEqual(mockDomainItem.createdAt);
+      expect(result.updatedAt).toEqual(mockDomainItem.updatedAt);
+      expect(result.deletedAt).toEqual(mockDomainItem.deletedAt);
+    });
+  });
+});

--- a/src/application/dto/output/item/item.restore.output.builder.ts
+++ b/src/application/dto/output/item/item.restore.output.builder.ts
@@ -1,0 +1,24 @@
+import { OutputBuilder } from '../output.builder';
+import { ItemRestoreOutputDto } from './item.restore.output.dto';
+import { Item } from '../../../../domain/inventory/items/entities/item.entity';
+
+export class ItemRestoreOutputBuilder
+  implements OutputBuilder<ItemRestoreOutputDto>
+{
+  private readonly _item: Item;
+
+  constructor(item: Item) {
+    this._item = item;
+  }
+  build(): ItemRestoreOutputDto {
+    const output = new ItemRestoreOutputDto();
+    output.id = this._item.id;
+    output.name = this._item.name;
+    output.quantity = this._item.quantity;
+    output.description = this._item.description;
+    output.createdAt = this._item.createdAt;
+    output.updatedAt = this._item.updatedAt;
+    output.deletedAt = this._item.deletedAt;
+    return output;
+  }
+}

--- a/src/application/dto/output/item/item.restore.output.dto.ts
+++ b/src/application/dto/output/item/item.restore.output.dto.ts
@@ -1,0 +1,77 @@
+import 'reflect-metadata';
+import { OutputDto } from '../output.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+
+export class ItemRestoreOutputDto implements OutputDto {
+  @ApiProperty({
+    example: 1,
+    description: `
+    物品ID
+    `,
+    type: Number,
+  })
+  @Expose({ name: 'id' })
+  id: number;
+
+  @ApiProperty({
+    example: 'テスト物品',
+    description: `
+    物品名
+    `,
+    type: String,
+  })
+  @Expose({ name: 'name' })
+  name: string;
+
+  @ApiProperty({
+    example: 1,
+    description: `
+    数量
+    `,
+    type: Number,
+  })
+  @Expose({ name: 'quantity' })
+  quantity: number;
+
+  @ApiProperty({
+    example: 'この物品はテスト用です。',
+    description: `
+    物品の詳細
+    `,
+    type: String,
+  })
+  @Expose({ name: 'description' })
+  description: string;
+
+  //作成日
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+    作成日時
+    `,
+    type: Date,
+  })
+  @Expose({ name: 'created_at' })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+    更新日時
+    `,
+    type: Date,
+  })
+  @Expose({ name: 'updated_at' })
+  updatedAt: Date;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+    削除日時
+    `,
+    type: Date,
+  })
+  @Expose({ name: 'deleted_at' })
+  deletedAt: Date | null;
+}

--- a/src/application/services/item/item.restore.interface.ts
+++ b/src/application/services/item/item.restore.interface.ts
@@ -1,0 +1,9 @@
+import { ItemRestoreInputDto } from '../../dto/input/item/item.restore.input.dto';
+import { ItemRestoreOutputDto } from '../../dto/output/item/item.restore.output.dto';
+import { ApplicationService } from '../application.service';
+import { ItemsDatasource } from '../../../infrastructure/datasources/items/items.datasource';
+
+export interface ItemRestoreServiceInterface
+  extends ApplicationService<ItemRestoreInputDto, ItemRestoreOutputDto> {
+  itemsDatasource: ItemsDatasource;
+}

--- a/src/application/services/item/item.restore.service.spec.ts
+++ b/src/application/services/item/item.restore.service.spec.ts
@@ -1,0 +1,266 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ItemRestoreService } from './item.restore.service';
+import { ItemsDatasource } from '../../../infrastructure/datasources/items/items.datasource';
+import { ItemRestoreInputDto } from '../../dto/input/item/item.restore.input.dto';
+import { Items } from '../../../infrastructure/orm/entities/items.entity';
+import { of, throwError } from 'rxjs';
+import { NotFoundException, ConflictException } from '@nestjs/common';
+
+describe('ItemRestoreService', () => {
+  let itemRestoreService: ItemRestoreService;
+  let itemsDatasource: ItemsDatasource;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const mockQueryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      startTransaction: jest.fn().mockResolvedValue(undefined),
+      commitTransaction: jest.fn().mockResolvedValue(undefined),
+      rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+      release: jest.fn().mockResolvedValue(undefined),
+      manager: {},
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ItemRestoreService,
+        {
+          provide: ItemsDatasource,
+          useValue: {
+            dataSource: {
+              createQueryRunner: jest.fn(() => mockQueryRunner),
+            },
+            findDeletedItemById: jest.fn(),
+            findCategoryIdsByItemId: jest.fn(),
+            restoreDeletedItemById: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    itemRestoreService = module.get<ItemRestoreService>(ItemRestoreService);
+    itemsDatasource = module.get<ItemsDatasource>(ItemsDatasource);
+
+    logSpy = jest
+      .spyOn(itemRestoreService['logger'], 'log')
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('should be defined', () => {
+    expect(itemRestoreService).toBeDefined();
+  });
+
+  describe('service', () => {
+    it('削除された物品を復元する', (done) => {
+      const input: ItemRestoreInputDto = { id: 1 };
+      const mockItem: Items = {
+        id: input.id,
+        name: 'Restored Item',
+        quantity: 5,
+        description: 'Restored Description',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: new Date(),
+        itemCategories: [],
+      };
+
+      const mockCategoryIds = [1, 2];
+
+      jest
+        .spyOn(itemsDatasource, 'findDeletedItemById')
+        .mockReturnValue(of(mockItem));
+      jest
+        .spyOn(itemsDatasource, 'findCategoryIdsByItemId')
+        .mockReturnValue(of(mockCategoryIds));
+      jest
+        .spyOn(itemsDatasource, 'restoreDeletedItemById')
+        .mockReturnValue(of(mockItem));
+
+      itemRestoreService.service(input).subscribe({
+        next: (output) => {
+          expect(output.id).toEqual(mockItem.id);
+          expect(output.name).toEqual(mockItem.name);
+          expect(output.quantity).toEqual(mockItem.quantity);
+          expect(output.description).toEqual(mockItem.description);
+          expect(logSpy).toHaveBeenCalledWith(
+            `Starting restore for item with ID: ${input.id}`
+          );
+          expect(logSpy).toHaveBeenCalledWith(
+            `Successfully restored item with ID: ${mockItem.id}`
+          );
+        },
+        error: (err) => {
+          done.fail(`Expected successful restoration, but got error: ${err}`);
+        },
+        complete: () => {
+          expect(itemsDatasource.findDeletedItemById).toHaveBeenCalledWith(
+            input.id
+          );
+          expect(itemsDatasource.findCategoryIdsByItemId).toHaveBeenCalledWith(
+            input.id
+          );
+          expect(itemsDatasource.restoreDeletedItemById).toHaveBeenCalledWith(
+            mockItem.id,
+            expect.anything()
+          );
+          done();
+        },
+      });
+    });
+
+    it('物品が見つからない場合は404エラーを返す', (done) => {
+      const input: ItemRestoreInputDto = { id: 1 };
+
+      jest
+        .spyOn(itemsDatasource, 'findDeletedItemById')
+        .mockReturnValue(
+          throwError(
+            () => new NotFoundException(`Item with ID ${input.id} not found`)
+          )
+        );
+
+      // serviceメソッド経由で404エラーが返ることを検証
+      itemRestoreService.service(input).subscribe({
+        next: () => {
+          done.fail('Expected an error to be thrown');
+        },
+        error: (err) => {
+          // publicメソッド(service)経由でNotFoundExceptionがthrowされることを検証
+          expect(err).toBeInstanceOf(NotFoundException);
+          expect(err.message).toBe(`Item with ID ${input.id} not found`);
+          done();
+        },
+        complete: () => {
+          done.fail('Expected an error to be thrown');
+        },
+      });
+    });
+
+    it('物品のカテゴリが見つからない場合は404エラーを返す', (done) => {
+      const input: ItemRestoreInputDto = { id: 1 };
+      const mockItem: Items = {
+        id: input.id,
+        name: 'Restored Item',
+        quantity: 5,
+        description: 'Restored Description',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: new Date(),
+        itemCategories: [],
+      };
+      jest
+        .spyOn(itemsDatasource, 'findDeletedItemById')
+        .mockReturnValue(of(mockItem));
+      jest
+        .spyOn(itemsDatasource, 'findCategoryIdsByItemId')
+        .mockReturnValue(
+          throwError(
+            () =>
+              new NotFoundException(
+                `Categories not found for item ID ${input.id}`
+              )
+          )
+        );
+      itemRestoreService.service(input).subscribe({
+        next: () => {
+          done.fail('Expected an error to be thrown');
+        },
+        error: (err) => {
+          expect(err).toBeInstanceOf(NotFoundException);
+          expect(err.message).toBe(
+            `Categories not found for item ID ${input.id}`
+          );
+          done();
+        },
+        complete: () => {
+          done.fail(
+            'Expected an error to be thrown, but completed successfully'
+          );
+        },
+      });
+    });
+
+    it('物品が論理削除されていない場合は409を返す', (done) => {
+      const input: ItemRestoreInputDto = { id: 1 };
+      const mockItem: Items = {
+        id: input.id,
+        name: 'Active Item',
+        quantity: 5,
+        description: 'Active Description',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null, // 論理削除されていない
+        itemCategories: [],
+      };
+
+      jest
+        .spyOn(itemsDatasource, 'findDeletedItemById')
+        .mockReturnValue(of(mockItem));
+      jest
+        .spyOn(itemsDatasource, 'findCategoryIdsByItemId')
+        .mockReturnValue(of([1, 2]));
+
+      itemRestoreService.service(input).subscribe({
+        next: () => {
+          done.fail('Expected an error to be thrown');
+        },
+        error: (err) => {
+          expect(err).toBeInstanceOf(ConflictException);
+          expect(err.message).toBe(`Item with ID ${input.id} is not deleted`);
+          done();
+        },
+        complete: () => {
+          done.fail(
+            'Expected an error to be thrown, but completed successfully'
+          );
+        },
+      });
+    });
+
+    it('トランザクション処理中にエラーが発生した場合は、InternalServerErrorExceptionをスローする', (done) => {
+      const input: ItemRestoreInputDto = { id: 1 };
+      const mockItem: Items = {
+        id: input.id,
+        name: 'Restored Item',
+        quantity: 5,
+        description: 'Restored Description',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: new Date(),
+        itemCategories: [],
+      };
+
+      jest
+        .spyOn(itemsDatasource, 'findDeletedItemById')
+        .mockReturnValue(of(mockItem));
+      jest
+        .spyOn(itemsDatasource, 'findCategoryIdsByItemId')
+        .mockReturnValue(of([1, 2]));
+      jest
+        .spyOn(itemsDatasource, 'restoreDeletedItemById')
+        .mockReturnValue(
+          throwError(() => new Error('Database transaction error'))
+        );
+
+      itemRestoreService.service(input).subscribe({
+        next: () => {
+          done.fail('Expected an error to be thrown');
+        },
+        error: (err) => {
+          expect(err).toBeInstanceOf(Error);
+          expect(err.message).toBe('Database transaction error');
+          done();
+        },
+        complete: () => {
+          done.fail(
+            'Expected an error to be thrown, but completed successfully'
+          );
+        },
+      });
+    });
+  });
+});

--- a/src/application/services/item/item.restore.service.ts
+++ b/src/application/services/item/item.restore.service.ts
@@ -1,0 +1,145 @@
+import {
+  map,
+  Observable,
+  switchMap,
+  forkJoin,
+  from,
+  catchError,
+  throwError,
+} from 'rxjs';
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  Logger,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { ItemRestoreServiceInterface } from './item.restore.interface';
+import { ItemRestoreInputDto } from '../../dto/input/item/item.restore.input.dto';
+import { ItemRestoreOutputDto } from '../../dto/output/item/item.restore.output.dto';
+import { ItemsDatasource } from '../../../infrastructure/datasources/items/items.datasource';
+import { ItemRestoreOutputBuilder } from '../../dto/output/item/item.restore.output.builder';
+import { ItemDomainFactory } from '../../../domain/inventory/items/factories/item.domain.factory';
+import { Items } from '../../../infrastructure/orm/entities/items.entity';
+
+@Injectable()
+export class ItemRestoreService implements ItemRestoreServiceInterface {
+  private readonly logger = new Logger(ItemRestoreService.name);
+
+  constructor(public readonly itemsDatasource: ItemsDatasource) {}
+
+  /**
+   * 削除された物品を復元する
+   * @param input - リクエスト情報
+   * @returns {Observable<ItemRestoreOutputDto>} - 復元された物品情報を含むObservableオブジェクト
+   * @throws {NotFoundException} - 物品が見つからない場合にスローされます。
+   * @throws {ConflictException} - 物品が削除されていない場合にスローされます。
+   */
+  service(input: ItemRestoreInputDto): Observable<ItemRestoreOutputDto> {
+    const itemId = input.id;
+    this.logger.log(`Starting restore for item with ID: ${itemId}`);
+
+    const queryRunner = this.itemsDatasource.dataSource.createQueryRunner();
+
+    return from(queryRunner.connect()).pipe(
+      switchMap(() => from(queryRunner.startTransaction())),
+      switchMap(() =>
+        forkJoin([
+          this.itemsDatasource.findDeletedItemById(itemId),
+          this.itemsDatasource.findCategoryIdsByItemId(itemId),
+        ]).pipe(
+          switchMap(([item, categoryIds]) => {
+            this.ensureItemExists(item, itemId);
+            this.ensureCategoriesExist(categoryIds, itemId);
+
+            const restoredItem = this.ensureItemIsDeleted(
+              item,
+              categoryIds
+            ).restore();
+
+            return this.itemsDatasource
+              .restoreDeletedItemById(restoredItem.id, queryRunner.manager)
+              .pipe(map(() => restoredItem));
+          }),
+          switchMap((restoredItem) =>
+            from(queryRunner.commitTransaction()).pipe(
+              map(() => {
+                this.logger.log(
+                  `Successfully restored item with ID: ${restoredItem.id}`
+                );
+                return new ItemRestoreOutputBuilder(restoredItem).build();
+              })
+            )
+          )
+        )
+      ),
+      catchError((err) =>
+        from(queryRunner.rollbackTransaction()).pipe(
+          switchMap(() => {
+            if (
+              err instanceof NotFoundException ||
+              err instanceof ConflictException
+            ) {
+              // 既に想定されている例外ならそのまま投げる
+              return throwError(() => err);
+            }
+            // それ以外の例外はInternalServerErrorExceptionに変換
+            return throwError(
+              () => new InternalServerErrorException(err.message)
+            );
+          })
+        )
+      ),
+      switchMap((result) => from(queryRunner.release()).pipe(map(() => result)))
+    );
+  }
+
+  /**
+   *
+   * @param item
+   * @param itemId
+   * @returns {void}
+   * @throws {NotFoundException} - 物品が見つからない場合にスローされます。
+   */
+  private ensureItemExists(item: Items, itemId: number): void {
+    if (!item) {
+      throw new NotFoundException(`Item with ID ${itemId} not found`);
+    }
+  }
+
+  /**
+   * @param categoryIds
+   * @param itemId
+   * @returns {void}
+   * @throws {NotFoundException} - カテゴリが見つからない場合にスローされます。
+   */
+  private ensureCategoriesExist(categoryIds: number[], itemId: number): void {
+    !categoryIds
+      ? (() => {
+          throw new NotFoundException(
+            `Categories not found for item with ID ${itemId}`
+          );
+        })()
+      : undefined;
+  }
+
+  /**
+   * @param item
+   * @param categoryIds
+   * @returns {ReturnType<typeof ItemDomainFactory.fromInfrastructureSingle>}
+   * @throws {ConflictException} - 物品が削除されていない場合にスローされます。
+   * */
+  private ensureItemIsDeleted(
+    item: Items,
+    categoryIds: number[]
+  ): ReturnType<typeof ItemDomainFactory.fromInfrastructureSingle> {
+    const domainItem = ItemDomainFactory.fromInfrastructureSingle(
+      item,
+      categoryIds
+    );
+    if (!domainItem.deletedAt) {
+      throw new ConflictException(`Item with ID ${item.id} is not deleted`);
+    }
+    return domainItem;
+  }
+}

--- a/src/domain/inventory/items/entities/item.entity.ts
+++ b/src/domain/inventory/items/entities/item.entity.ts
@@ -182,4 +182,17 @@ export class Item {
       this._categoryIds
     );
   }
+
+  restore(): Item {
+    return new Item(
+      this._id,
+      this._name,
+      this._quantity,
+      this._description,
+      this._createdAt,
+      new Date(),
+      null,
+      this._categoryIds
+    );
+  }
 }

--- a/src/presentation/controllers/item/item.controller.ts
+++ b/src/presentation/controllers/item/item.controller.ts
@@ -16,6 +16,7 @@ import { ItemUpdateServiceInterface } from '../../../application/services/item/i
 import { ItemDeleteServiceInterface } from '../../../application/services/item/item.delete.interface';
 import { ItemSingleServiceInterface } from '../../../application/services/item/item.single.interface';
 import { DeletedItemListServiceInterface } from '../../../application/services/item/deleted.item.list.interface';
+import { ItemRestoreServiceInterface } from '../../../application/services/item/item.restore.interface';
 import { Observable } from 'rxjs';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ItemListInputDto } from '../../../application/dto/input/item/item.list.input.dto';
@@ -30,6 +31,8 @@ import { ItemSingleInputDto } from '../../../application/dto/input/item/item.sin
 import { ItemSingleOutputDto } from '../../../application/dto/output/item/item.single.output.dto';
 import { DeletedItemListInputDto } from '../../../application/dto/input/item/deleted.item.list.input.dto';
 import { DeletedItemListOutputDto } from '../../../application/dto/output/item/deleted.item.list.output.dto';
+import { ItemRestoreInputDto } from '../../../application/dto/input/item/item.restore.input.dto';
+import { ItemRestoreOutputDto } from '../../../application/dto/output/item/item.restore.output.dto';
 
 @ApiTags('items')
 @Controller('items')
@@ -46,7 +49,9 @@ export class ItemController {
     @Inject('ItemSingleServiceInterface')
     private readonly ItemSingleService: ItemSingleServiceInterface,
     @Inject('DeletedItemListServiceInterface')
-    private readonly DeletedItemListService: DeletedItemListServiceInterface
+    private readonly DeletedItemListService: DeletedItemListServiceInterface,
+    @Inject('ItemRestoreServiceInterface')
+    private readonly ItemRestoreService: ItemRestoreServiceInterface
   ) {}
 
   /**
@@ -88,6 +93,27 @@ export class ItemController {
     @Query() query: DeletedItemListInputDto
   ): Observable<DeletedItemListOutputDto> {
     return this.DeletedItemListService.service(query);
+  }
+
+  /**
+   * @param request - リクエスト情報
+   * @return {Observable<ItemRestoreOutputDto>} - 復元された物品情報を含むObservable
+   */
+  @ApiOperation({
+    summary: '削除された物品を復元するエンドポイント',
+    description: '削除された物品を復元するAPI',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Restored',
+    type: ItemRestoreOutputDto,
+  })
+  @Patch('restore/:item_id')
+  restoreDeletedItem(
+    @Param('item_id', ParseIntPipe) id: number
+  ): Observable<ItemRestoreOutputDto> {
+    const request: ItemRestoreInputDto = { id };
+    return this.ItemRestoreService.service(request);
   }
 
   /**

--- a/src/presentation/modules/items.module.ts
+++ b/src/presentation/modules/items.module.ts
@@ -7,6 +7,7 @@ import { ItemUpdateService } from '../../application/services/item/item.update.s
 import { ItemDeleteService } from '../../application/services/item/item.delete.service';
 import { ItemSingleService } from '../../application/services/item/item.single.service';
 import { DeletedItemListService } from '../../application/services/item/deleted.item.list.service';
+import { ItemRestoreService } from '../../application/services/item/item.restore.service';
 import { DatabaseModule } from './database.module';
 import { ItemsDatasource } from 'src/infrastructure/datasources/items/items.datasource';
 import { CategoriesModule } from './categories.module';
@@ -45,6 +46,10 @@ import { RabbitMQModule } from './rabbitmq.module';
     {
       provide: 'DeletedItemListServiceInterface',
       useClass: DeletedItemListService,
+    },
+    {
+      provide: 'ItemRestoreServiceInterface',
+      useClass: ItemRestoreService,
     },
   ],
 })


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#71 
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- controllerに追加
- I/Oの追加
- クエリの追加
- アプリケーションサービスの追加
- ドメインエンティティに状態管理を追加
- 単体テストを追加
- APIドキュメントを追加

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

## 動作したときのスクリーンショット
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 復元例
```
Nest] 71953  - 2025/06/08 13:43:49     LOG [LoggerInterceptor.name] Request: [PATCH] /items/restore/13
[Nest] 71953  - 2025/06/08 13:43:49     LOG [ItemRestoreService] Starting restore for item with ID: 13
query: START TRANSACTION
query: SELECT category_id AS `id` FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` = ? ) AND ( `item_categories`.`deleted_at` IS NULL ) -- PARAMETERS: [13]
query: SELECT `items`.`id` AS `items_id`, `items`.`name` AS `items_name`, `items`.`quantity` AS `items_quantity`, `items`.`description` AS `items_description`, `items`.`created_at` AS `items_created_at`, `items`.`updated_at` AS `items_updated_at`, `items`.`deleted_at` AS `items_deleted_at` FROM `items` `items` WHERE `items`.`id` = ? -- PARAMETERS: [13]
query: UPDATE `items` SET `updated_at` = ?, `deleted_at` = ? WHERE `id` = ? -- PARAMETERS: ["2025-06-08T04:43:49.175Z",null,13]
query: COMMIT
[Nest] 71953  - 2025/06/08 13:43:49     LOG [ItemRestoreService] Successfully restored item with ID: 13
[Nest] 71953  - 2025/06/08 13:43:49     LOG [LoggerInterceptor.name] Response: [PATCH] /items/restore/13 89ms - {"id":13,"name":"Refined Metal Chair","quantity":50,"description":"Savor the fluffy essence in our Shirt, designed for lined culinary adventures","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-06-08T04:43:49.174Z","deletedAt":null
```

- 復元失敗例
```
[Nest] 78051  - 2025/06/08 13:53:32     LOG [LoggerInterceptor.name] Request: [PATCH] /items/restore/13
[Nest] 78051  - 2025/06/08 13:53:32     LOG [ItemRestoreService] Starting restore for item with ID: 13
query: START TRANSACTION
query: SELECT category_id AS `id` FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` = ? ) AND ( `item_categories`.`deleted_at` IS NULL ) -- PARAMETERS: [13]
query: SELECT `items`.`id` AS `items_id`, `items`.`name` AS `items_name`, `items`.`quantity` AS `items_quantity`, `items`.`description` AS `items_description`, `items`.`created_at` AS `items_created_at`, `items`.`updated_at` AS `items_updated_at`, `items`.`deleted_at` AS `items_deleted_at` FROM `items` `items` WHERE `items`.`id` = ? -- PARAMETERS: [13]
query: ROLLBACK
[Nest] 78051  - 2025/06/08 13:53:32   ERROR [LoggerInterceptor.name] Error: [PATCH] /items/restore/13 48ms - Item with ID 13 is not deleted and cannot be restored
```
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->