### PR TITLE
feat：論理削除された物品単体を取得するエンドポイントの作成

### DIFF
--- a/src/application/dto/input/item/deleted.item.single.input.dto.ts
+++ b/src/application/dto/input/item/deleted.item.single.input.dto.ts
@@ -1,0 +1,17 @@
+import { InputDto } from '../input.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsInt, Min } from 'class-validator';
+
+export class DeletedItemSingleInputDto implements InputDto {
+  @ApiProperty({
+    example: '1',
+    description: '物品ID',
+    type: Number,
+  })
+  @IsNotEmpty()
+  @IsInt()
+  @Min(1)
+  @Transform(({ value }) => parseInt(value))
+  id: number;
+}

--- a/src/application/dto/output/item/deleted.item.single.output.builder.spec.ts
+++ b/src/application/dto/output/item/deleted.item.single.output.builder.spec.ts
@@ -1,0 +1,86 @@
+import { DeletedItemSingleOutputBuilder } from './deleted.item.single.output.builder';
+import { DeletedItemSingleOutputDto } from './deleted.item.single.output.dto';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { Item } from '../../../../domain/inventory/items/entities/item.entity';
+import { Category } from '../../../../domain/inventory/items/entities/category.entity';
+
+describe('DeletedItemSingleOutputBuilder', () => {
+  const now = new Date();
+  const mockDomainItem: Item = new Item(
+    1,
+    'Item 1',
+    10,
+    'Description 1',
+    now,
+    now,
+    now,
+    [1]
+  );
+  const mockDomainCategories: Category[] = [
+    new Category(1, 'Category 1', 'その他のカテゴリ', now, now, null),
+  ];
+  const mockOutput: DeletedItemSingleOutputDto = {
+    id: 1,
+    name: 'Item 1',
+    quantity: 10,
+    description: 'Description 1',
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: now,
+    itemCategories: [
+      {
+        id: 1,
+        name: 'Category 1',
+        description: 'その他のカテゴリ',
+      },
+    ],
+  };
+
+  describe('build', () => {
+    it('DeletedItemSingleOutputDtoを返す', () => {
+      const builder = new DeletedItemSingleOutputBuilder(
+        mockDomainItem,
+        mockDomainCategories
+      );
+
+      const result = builder.build();
+      expect(result).toBeInstanceOf(DeletedItemSingleOutputDto);
+      expect(result).toMatchObject({
+        id: mockOutput.id,
+        name: mockOutput.name,
+        quantity: mockOutput.quantity,
+        description: mockOutput.description,
+      });
+      expect(result.createdAt.getTime()).toBeCloseTo(
+        mockOutput.createdAt.getTime(),
+        -2
+      );
+      expect(result.updatedAt.getTime()).toBeCloseTo(
+        mockOutput.updatedAt.getTime(),
+        -2
+      );
+      expect(result.deletedAt.getTime()).toBeCloseTo(
+        mockOutput.deletedAt.getTime(),
+        -2
+      );
+      expect(result.itemCategories.length).toEqual(
+        mockOutput.itemCategories.length
+      );
+      expect(result.itemCategories[0]).toMatchObject({
+        id: mockDomainCategories[0].id,
+        name: mockDomainCategories[0].name,
+        description: mockDomainCategories[0].description,
+      });
+    });
+
+    it('itemがnullの場合、404エラーを返す', () => {
+      const builder = new DeletedItemSingleOutputBuilder(
+        null,
+        mockDomainCategories
+      );
+      expect(() => builder.build()).toThrow(
+        new HttpException('Items not found', HttpStatus.NOT_FOUND)
+      );
+    });
+  });
+});

--- a/src/application/dto/output/item/deleted.item.single.output.builder.ts
+++ b/src/application/dto/output/item/deleted.item.single.output.builder.ts
@@ -1,0 +1,39 @@
+import { OutputBuilder } from '../output.builder';
+import { DeletedItemSingleOutputDto } from './deleted.item.single.output.dto';
+import { Item } from '../../../../domain/inventory/items/entities/item.entity';
+import { Category } from 'src/domain/inventory/items/entities/category.entity';
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class DeletedItemSingleOutputBuilder
+  implements OutputBuilder<DeletedItemSingleOutputDto>
+{
+  private _item: Item;
+  private _categories: Category[];
+
+  constructor(item: Item, categories: Category[]) {
+    this._item = item;
+    this._categories = categories;
+  }
+
+  build(): DeletedItemSingleOutputDto {
+    if (!this._item) {
+      throw new HttpException('Items not found', HttpStatus.NOT_FOUND);
+    }
+    const output = new DeletedItemSingleOutputDto();
+    output.id = this._item.id;
+    output.name = this._item.name;
+    output.quantity = this._item.quantity;
+    output.description = this._item.description;
+    output.createdAt = this._item.createdAt;
+    output.updatedAt = this._item.updatedAt;
+    output.deletedAt = this._item.deletedAt;
+    output.itemCategories = this._categories.map((category) => ({
+      id: category.id,
+      name: category.name,
+      description: category.description,
+      createdAt: category.createdAt,
+      updatedAt: category.updatedAt,
+    }));
+    return output;
+  }
+}

--- a/src/application/dto/output/item/deleted.item.single.output.dto.ts
+++ b/src/application/dto/output/item/deleted.item.single.output.dto.ts
@@ -1,0 +1,128 @@
+import 'reflect-metadata';
+import { OutputDto } from '../output.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+
+export class itemCategories {
+  @ApiProperty({
+    example: 1,
+    description: `
+    カテゴリーID
+    `,
+    type: Number,
+  })
+  @Expose({ name: 'id' })
+  id: number;
+
+  @ApiProperty({
+    example: 'テストカテゴリー',
+    description: `
+    カテゴリー名
+    `,
+    type: String,
+  })
+  @Expose({ name: 'name' })
+  name: string;
+
+  @ApiProperty({
+    example: 'このカテゴリーはテスト用です。',
+    description: `
+    カテゴリーの詳細
+    `,
+    type: String,
+  })
+  @Expose({ name: 'description' })
+  description: string;
+}
+export class DeletedItemSingleOutputDto implements OutputDto {
+  @ApiProperty({
+    example: 1,
+    description: `
+    物品ID
+    `,
+    type: Number,
+  })
+  @Expose({ name: 'id' })
+  id: number;
+
+  @ApiProperty({
+    example: 'テスト物品',
+    description: `
+    物品名
+    `,
+    type: String,
+  })
+  @Expose({ name: 'name' })
+  name: string;
+
+  @ApiProperty({
+    example: 1,
+    description: `
+    数量
+    `,
+    type: Number,
+  })
+  @Expose({ name: 'quantity' })
+  quantity: number;
+
+  @ApiProperty({
+    example: 'この物品はテスト用です。',
+    description: `
+    物品の詳細
+    `,
+    type: String,
+  })
+  @Expose({ name: 'description' })
+  description: string;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+    作成日時
+    `,
+    type: String,
+  })
+  @Expose({ name: 'created_at' })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+    更新日時
+    `,
+    type: String,
+  })
+  @Expose({ name: 'updated_at' })
+  updatedAt: Date;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: `
+    削除日時
+    `,
+    type: String,
+  })
+  @Expose({ name: 'deleted_at' })
+  deletedAt: Date;
+
+  @ApiProperty({
+    example: [
+      {
+        id: 1,
+        name: 'テストカテゴリー',
+        description: 'このカテゴリーはテスト用です。',
+      },
+      {
+        id: 2,
+        name: 'テストカテゴリー2',
+        description: 'このカテゴリーはテスト用です。',
+      },
+    ],
+    description: `
+    カテゴリー
+    `,
+    type: [itemCategories],
+  })
+  @Expose({ name: 'item_categories' })
+  itemCategories: itemCategories[];
+}

--- a/src/application/services/item/deleted.item.single.interface.ts
+++ b/src/application/services/item/deleted.item.single.interface.ts
@@ -1,0 +1,14 @@
+import { DeletedItemSingleInputDto } from '../../dto/input/item/deleted.item.single.input.dto';
+import { DeletedItemSingleOutputDto } from '../../dto/output/item/deleted.item.single.output.dto';
+import { ApplicationService } from '../application.service';
+import { ItemsDatasource } from '../../../infrastructure/datasources/items/items.datasource';
+import { CategoriesDatasource } from '../../../infrastructure/datasources/categories/categories.datasource';
+
+export interface DeletedItemSingleServiceInterface
+  extends ApplicationService<
+    DeletedItemSingleInputDto,
+    DeletedItemSingleOutputDto
+  > {
+  itemsDatasource: ItemsDatasource;
+  categoriesDatasource: CategoriesDatasource;
+}

--- a/src/application/services/item/deleted.item.single.service.spec.ts
+++ b/src/application/services/item/deleted.item.single.service.spec.ts
@@ -1,0 +1,235 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DeletedItemSingleService } from './deleted.item.single.service';
+import { DeletedItemSingleInputDto } from '../../../application/dto/input/item/deleted.item.single.input.dto';
+import { DeletedItemSingleOutputDto } from '../../../application/dto/output/item/deleted.item.single.output.dto';
+import { ItemsDatasource } from '../../../infrastructure/datasources/items/items.datasource';
+import { CategoriesDatasource } from '../../../infrastructure/datasources/categories/categories.datasource';
+import { Items } from '../../../infrastructure/orm/entities/items.entity';
+import { Categories } from '../../../infrastructure/orm/entities/categories.entity';
+import { Item } from '../../../domain/inventory/items/entities/item.entity';
+import { Category } from '../../../domain/inventory/items/entities/category.entity';
+import { ItemDomainFactory } from '../../../domain/inventory/items/factories/item.domain.factory';
+import { CategoryDomainFactory } from '../../../domain/inventory/items/factories/category.domain.factory';
+import { of } from 'rxjs';
+import { NotFoundException } from '@nestjs/common';
+
+describe('DeletedItemSingleService', () => {
+  let deletedItemSingleService: DeletedItemSingleService;
+  let itemsDatasource: ItemsDatasource;
+  let categoriesDatasource: CategoriesDatasource;
+
+  const mockItemDomainFactory = {
+    fromInfrastructureSingle: jest.fn(),
+  };
+  const mockCategoryDomainFactory = {
+    fromInfrastructureList: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeletedItemSingleService,
+        {
+          provide: ItemsDatasource,
+          useValue: {
+            findDeletedItemById: jest.fn(),
+          },
+        },
+        {
+          provide: CategoriesDatasource,
+          useValue: {
+            findCategoriesByItemId: jest.fn(),
+          },
+        },
+        {
+          provide: ItemDomainFactory,
+          useValue: mockItemDomainFactory,
+        },
+        {
+          provide: CategoryDomainFactory,
+          useValue: mockCategoryDomainFactory,
+        },
+      ],
+    }).compile();
+
+    deletedItemSingleService = module.get<DeletedItemSingleService>(
+      DeletedItemSingleService
+    );
+    itemsDatasource = module.get<ItemsDatasource>(ItemsDatasource);
+    categoriesDatasource =
+      module.get<CategoriesDatasource>(CategoriesDatasource);
+  });
+
+  it('should be defined', () => {
+    expect(deletedItemSingleService).toBeDefined();
+  });
+
+  it('論理削除削除されている物品を1件取得する', (done) => {
+    const itemId: DeletedItemSingleInputDto = {
+      id: 1,
+    };
+
+    const mockItem: Items = {
+      id: 1,
+      name: 'Item 1',
+      quantity: 10,
+      description: 'Description 1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: new Date(),
+      itemCategories: [],
+    };
+
+    const mockCategories: Categories[] = [
+      {
+        id: 1,
+        name: 'Category 1',
+        description: 'Description 1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+        itemCategories: [],
+      },
+      {
+        id: 2,
+        name: 'Category 2',
+        description: 'Description 2',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+        itemCategories: [],
+      },
+    ];
+
+    const mockDomainCategories: Category[] = [
+      new Category(
+        1,
+        'Category 1',
+        'Description 1',
+        new Date(),
+        new Date(),
+        null
+      ),
+      new Category(
+        2,
+        'Category 2',
+        'Description 2',
+        new Date(),
+        new Date(),
+        null
+      ),
+    ];
+
+    const mockDomainItem: Item = new Item(
+      mockItem.id,
+      mockItem.name,
+      mockItem.quantity,
+      mockItem.description,
+      mockItem.createdAt,
+      mockItem.updatedAt,
+      mockItem.deletedAt,
+      [1, 2]
+    );
+
+    jest
+      .spyOn(itemsDatasource, 'findDeletedItemById')
+      .mockReturnValue(of(mockItem));
+    jest
+      .spyOn(categoriesDatasource, 'findCategoriesByItemId')
+      .mockReturnValue(of(mockCategories));
+    jest
+      .spyOn(mockItemDomainFactory, 'fromInfrastructureSingle')
+      .mockReturnValue(mockDomainItem);
+    jest
+      .spyOn(mockCategoryDomainFactory, 'fromInfrastructureList')
+      .mockReturnValue(mockDomainCategories);
+
+    deletedItemSingleService.service(itemId).subscribe({
+      next: (result: DeletedItemSingleOutputDto) => {
+        expect(result).toBeInstanceOf(DeletedItemSingleOutputDto);
+        expect(result.id).toBe(mockItem.id);
+        expect(result.name).toBe(mockItem.name);
+        expect(result.quantity).toBe(mockItem.quantity);
+        expect(result.description).toBe(mockItem.description);
+        expect(result.createdAt).toBe(mockItem.createdAt);
+        expect(result.updatedAt).toBe(mockItem.updatedAt);
+        expect(result.deletedAt).toBe(mockItem.deletedAt);
+        expect(result.itemCategories).toEqual(
+          mockDomainCategories.map((category) => ({
+            id: category.id,
+            name: category.name,
+            description: category.description,
+            createdAt: category.createdAt,
+            updatedAt: category.updatedAt,
+          }))
+        );
+      },
+      error: (error) => {
+        expect(error).toBeInstanceOf(NotFoundException);
+        expect(error.message).toBe(`Item with id ${itemId.id} not found`);
+      },
+      complete: () => {
+        done();
+      },
+    });
+  });
+
+  it('論理削除されている物品が存在しない場合、404エラーを返す', (done) => {
+    const itemId: DeletedItemSingleInputDto = {
+      id: 1,
+    };
+    jest
+      .spyOn(itemsDatasource, 'findDeletedItemById')
+      .mockReturnValue(of(undefined));
+
+    deletedItemSingleService.service(itemId).subscribe({
+      next: () => {
+        done.fail('Expected an error, but got a result');
+      },
+      error: (error) => {
+        expect(error).toBeInstanceOf(NotFoundException);
+        expect(error.message).toBe(`Item not found`);
+        done();
+      },
+      complete: () => {
+        done();
+      },
+    });
+  });
+
+  it('カテゴリーが存在しない場合、404エラーを返す', (done) => {
+    const itemId: DeletedItemSingleInputDto = {
+      id: 1,
+    };
+    const mockItem: Items = {
+      id: 1,
+      name: 'Item 1',
+      quantity: 10,
+      description: 'Description 1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: new Date(),
+      itemCategories: [],
+    };
+    jest
+      .spyOn(itemsDatasource, 'findDeletedItemById')
+      .mockReturnValue(of(mockItem));
+    jest
+      .spyOn(categoriesDatasource, 'findCategoriesByItemId')
+      .mockReturnValue(of(undefined));
+
+    deletedItemSingleService.service(itemId).subscribe({
+      next: () => {
+        done.fail('Expected an error, but got a result');
+      },
+      error: (error) => {
+        expect(error).toBeInstanceOf(NotFoundException);
+        expect(error.message).toBe('Categories not found');
+        done();
+      },
+      complete: () => {
+        done();
+      },
+    });
+  });
+});

--- a/src/application/services/item/deleted.item.single.service.ts
+++ b/src/application/services/item/deleted.item.single.service.ts
@@ -1,0 +1,98 @@
+import {
+  defaultIfEmpty,
+  filter,
+  map,
+  mergeMap,
+  Observable,
+  switchMap,
+  throwError,
+} from 'rxjs';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { DeletedItemSingleServiceInterface } from './deleted.item.single.interface';
+import { DeletedItemSingleInputDto } from '../../dto/input/item/deleted.item.single.input.dto';
+import { DeletedItemSingleOutputDto } from '../../dto/output/item/deleted.item.single.output.dto';
+import { DeletedItemSingleOutputBuilder } from '../../dto/output/item/deleted.item.single.output.builder';
+import { ItemsDatasource } from '../../../infrastructure/datasources/items/items.datasource';
+import { CategoriesDatasource } from '../../../infrastructure/datasources/categories/categories.datasource';
+import { Items } from '../../../infrastructure/orm/entities/items.entity';
+import { Categories } from '../../../infrastructure/orm/entities/categories.entity';
+import { ItemDomainFactory } from '../../../domain/inventory/items/factories/item.domain.factory';
+import { CategoryDomainFactory } from '../../../domain/inventory/items/factories/category.domain.factory';
+import { ItemNotFoundOperator } from '../../../common/types/rxjs-operator.types';
+import { CategoriesNotFoundOperator } from '../../../common/types/rxjs-operator.types';
+
+@Injectable()
+export class DeletedItemSingleService
+  implements DeletedItemSingleServiceInterface
+{
+  constructor(
+    public readonly itemsDatasource: ItemsDatasource,
+    public readonly categoriesDatasource: CategoriesDatasource
+  ) {}
+
+  /**
+   * 削除された物品を1件取得する
+   * @param {DeletedItemSingleInputDto} input - リクエスト情報
+   * @returns{Observable<DeletedItemSingleOutputDto>} - 削除された物品情報を含むObservableオブジェクト
+   *
+   * @throws {HttpException} 物品が見つからない場合、404エラーをスローします。
+   */
+
+  service(
+    input: DeletedItemSingleInputDto
+  ): Observable<DeletedItemSingleOutputDto> {
+    const itemId = input.id;
+
+    return this.itemsDatasource.findDeletedItemById(itemId).pipe(
+      this.throwIfItemNotFound(),
+      switchMap((item) =>
+        this.categoriesDatasource.findCategoriesByItemId(item.id).pipe(
+          this.throwIfCategoriesNotFound(),
+          map((categories) => {
+            const categoryIds = categories.map((category) => category.id);
+            const domainItem = ItemDomainFactory.fromInfrastructureSingle(
+              item,
+              categoryIds
+            );
+            const domainCategories =
+              CategoryDomainFactory.fromInfrastructureList(categories);
+
+            const builder = new DeletedItemSingleOutputBuilder(
+              domainItem,
+              domainCategories
+            );
+            return builder.build();
+          })
+        )
+      )
+    );
+  }
+
+  // itemが存在しないときのエラーハンドリング（pipeable operator, 型エイリアス利用）
+  private throwIfItemNotFound = (): ItemNotFoundOperator => (source$) =>
+    source$.pipe(
+      filter((item: Items | undefined): item is Items => !!item),
+      defaultIfEmpty(undefined),
+      mergeMap((item) =>
+        item
+          ? [item]
+          : throwError(() => new NotFoundException('Item not found'))
+      )
+    );
+
+  // categoriesが存在しないときのエラーハンドリング（pipeable operator, 型エイリアス利用）
+  private throwIfCategoriesNotFound =
+    (): CategoriesNotFoundOperator => (source$) =>
+      source$.pipe(
+        filter(
+          (categories: Categories[] | undefined): categories is Categories[] =>
+            !!categories && categories.length > 0
+        ),
+        defaultIfEmpty(undefined),
+        mergeMap((categories) =>
+          categories
+            ? [categories]
+            : throwError(() => new NotFoundException('Categories not found'))
+        )
+      );
+}

--- a/src/common/types/rxjs-operator.types.ts
+++ b/src/common/types/rxjs-operator.types.ts
@@ -1,0 +1,10 @@
+import { Items } from '../../infrastructure/orm/entities/items.entity';
+import { Categories } from '../../infrastructure/orm/entities/categories.entity';
+import { OperatorFunction } from 'rxjs';
+
+export type ItemNotFoundOperator = OperatorFunction<Items | undefined, Items>;
+
+export type CategoriesNotFoundOperator = OperatorFunction<
+  Categories[] | undefined,
+  Categories[]
+>;

--- a/src/presentation/controllers/item/item.controller.ts
+++ b/src/presentation/controllers/item/item.controller.ts
@@ -10,15 +10,16 @@ import {
   Param,
   ParseIntPipe,
 } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ItemListServiceInterface } from '../../../application/services/item/item.list.interface';
 import { ItemRegisterServiceInterface } from '../../../application/services/item/item.register.interface';
 import { ItemUpdateServiceInterface } from '../../../application/services/item/item.update.interface';
 import { ItemDeleteServiceInterface } from '../../../application/services/item/item.delete.interface';
 import { ItemSingleServiceInterface } from '../../../application/services/item/item.single.interface';
 import { DeletedItemListServiceInterface } from '../../../application/services/item/deleted.item.list.interface';
+import { DeletedItemSingleServiceInterface } from '../../../application/services/item/deleted.item.single.interface';
 import { ItemRestoreServiceInterface } from '../../../application/services/item/item.restore.interface';
-import { Observable } from 'rxjs';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ItemListInputDto } from '../../../application/dto/input/item/item.list.input.dto';
 import { ItemListOutputDto } from '../../../application/dto/output/item/item.list.output.dto';
 import { ItemRegisterInputDto } from '../../../application/dto/input/item/item.register.input.dto';
@@ -31,6 +32,8 @@ import { ItemSingleInputDto } from '../../../application/dto/input/item/item.sin
 import { ItemSingleOutputDto } from '../../../application/dto/output/item/item.single.output.dto';
 import { DeletedItemListInputDto } from '../../../application/dto/input/item/deleted.item.list.input.dto';
 import { DeletedItemListOutputDto } from '../../../application/dto/output/item/deleted.item.list.output.dto';
+import { DeletedItemSingleInputDto } from '../../../application/dto/input/item/deleted.item.single.input.dto';
+import { DeletedItemSingleOutputDto } from '../../../application/dto/output/item/deleted.item.single.output.dto';
 import { ItemRestoreInputDto } from '../../../application/dto/input/item/item.restore.input.dto';
 import { ItemRestoreOutputDto } from '../../../application/dto/output/item/item.restore.output.dto';
 
@@ -50,6 +53,8 @@ export class ItemController {
     private readonly ItemSingleService: ItemSingleServiceInterface,
     @Inject('DeletedItemListServiceInterface')
     private readonly DeletedItemListService: DeletedItemListServiceInterface,
+    @Inject('DeletedItemSingleServiceInterface')
+    private readonly DeletedItemSingleService: DeletedItemSingleServiceInterface,
     @Inject('ItemRestoreServiceInterface')
     private readonly ItemRestoreService: ItemRestoreServiceInterface
   ) {}
@@ -93,6 +98,27 @@ export class ItemController {
     @Query() query: DeletedItemListInputDto
   ): Observable<DeletedItemListOutputDto> {
     return this.DeletedItemListService.service(query);
+  }
+
+  /**
+   * @param request - リクエスト情報
+   * @return {Observable<DeletedItemSingleOutputDto>} - 削除された物品の個別情報を含むObservable
+   */
+  @ApiOperation({
+    summary: '削除された物品の個別情報を返すエンドポイント',
+    description: '削除された物品の個別情報を返すAPI',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'OK',
+    type: DeletedItemSingleOutputDto,
+  })
+  @Get('deleted/:item_id')
+  findDeletedItemSingle(
+    @Param('item_id', ParseIntPipe) id: number
+  ): Observable<DeletedItemSingleOutputDto> {
+    const request: DeletedItemSingleInputDto = { id };
+    return this.DeletedItemSingleService.service(request);
   }
 
   /**

--- a/src/presentation/modules/items.module.ts
+++ b/src/presentation/modules/items.module.ts
@@ -7,6 +7,7 @@ import { ItemUpdateService } from '../../application/services/item/item.update.s
 import { ItemDeleteService } from '../../application/services/item/item.delete.service';
 import { ItemSingleService } from '../../application/services/item/item.single.service';
 import { DeletedItemListService } from '../../application/services/item/deleted.item.list.service';
+import { DeletedItemSingleService } from '../../application/services/item/deleted.item.single.service';
 import { ItemRestoreService } from '../../application/services/item/item.restore.service';
 import { DatabaseModule } from './database.module';
 import { ItemsDatasource } from 'src/infrastructure/datasources/items/items.datasource';
@@ -46,6 +47,10 @@ import { RabbitMQModule } from './rabbitmq.module';
     {
       provide: 'DeletedItemListServiceInterface',
       useClass: DeletedItemListService,
+    },
+    {
+      provide: 'DeletedItemSingleServiceInterface',
+      useClass: DeletedItemSingleService,
     },
     {
       provide: 'ItemRestoreServiceInterface',


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#75 
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- controllerの追加
- I/Oの追加
- アプリケーションサービスの追加
- 単体テストの実施
- APIドキュメントの追加

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
- 特になし

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
```
npm run start:dev
```

- そのあと、postmanなどで確認する

## 動作したときのスクリーンショット
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
```
[Nest] 59048  - 2025/06/22 1:47:01     LOG [LoggerInterceptor.name] Request: [GET] /items/deleted/27
query: SELECT `items`.`id` AS `items_id`, `items`.`name` AS `items_name`, `items`.`quantity` AS `items_quantity`, `items`.`description` AS `items_description`, `items`.`created_at` AS `items_created_at`, `items`.`updated_at` AS `items_updated_at`, `items`.`deleted_at` AS `items_deleted_at` FROM `items` `items` WHERE `items`.`id` = ? -- PARAMETERS: [27]
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt, `categories`.`deleted_at` AS deletedAt FROM `categories` `categories` INNER JOIN `item_categories` `item_categories` ON  `categories`.`id` = `item_categories`.`category_id` AND `item_categories`.`deleted_at` IS NULL WHERE ( `item_categories`.`item_id` = ? AND `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) -- PARAMETERS: [27]
[Nest] 59048  - 2025/06/22 1:47:01     LOG [LoggerInterceptor.name] Response: [GET] /items/deleted/27 27ms - {"id":27,"name":"めがね","quantity":2,"description":"ブルーライトカットが入っている","createdAt":"2025-05-10T15:40:07.000Z","updatedAt":"2025-06-21T13:54:37.000Z","deletedAt":"2025-06-21T13:54:37.389Z","itemCategories":[{"id":3,"name":"その他","description":"その他のカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"}]}
```
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->