### PR TITLE
fix：更新処理のObservableの順番の修正

### DIFF
--- a/src/application/services/item/item.update.service.spec.ts
+++ b/src/application/services/item/item.update.service.spec.ts
@@ -531,7 +531,7 @@ describe('ItemUpdateService', () => {
         .spyOn(itemsDatasource.dataSource.manager, 'transaction')
         .mockImplementation(() => {
           throw new InternalServerErrorException(
-            'トランザクション処理中にエラーが発生しました'
+            '更新処理中にエラーが発生しました'
           );
         });
 
@@ -541,9 +541,7 @@ describe('ItemUpdateService', () => {
         },
         error: (error) => {
           expect(error).toBeInstanceOf(InternalServerErrorException);
-          expect(error.message).toBe(
-            'トランザクション処理中にエラーが発生しました'
-          );
+          expect(error.message).toBe('更新処理中にエラーが発生しました');
           done();
         },
         complete: () => {


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- トランザクション処理とObservableの順番がことなっていたため、更新処理がうまくできていなかった

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- クエリの修正
- Observableの修正
- 単体テストの修正

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

## 動作したときのスクリーンショット
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 更新処理のlog
```
[Nest] 66770  - 2025/06/29 21:04:44     LOG [LoggerInterceptor.name] Request: [PATCH] /items/26
[Nest] 66770  - 2025/06/29 21:04:44     LOG [ItemUpdateService] Starting update for item with ID: 26
query: SELECT * FROM `items` `items` WHERE ( `items`.`id` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: [26]
query: SELECT category_id AS `id` FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` = ? ) AND ( `item_categories`.`deleted_at` IS NULL ) -- PARAMETERS: [26]
query: START TRANSACTION
query: UPDATE `items` SET `name` = ?, `quantity` = ?, `description` = ?, `updated_at` = ? WHERE `id` = ? -- PARAMETERS: ["オフィスチェア",3,"作業するときによく利用し、リクライニングもできる","2025-06-29T12:04:44.385Z",26]
query: COMMIT
[Nest] 66770  - 2025/06/29 21:04:44     LOG [LoggerInterceptor.name] Response: [PATCH] /items/26 24ms - {"id":26,"name":"オフィスチェア","quantity":3,"description":"作業するときによく利用し、リクライニングもできる","updatedAt":"2025-06-29T12:04:44.383Z","itemCategories":[]}
[Nest] 66770  - 2025/06/29 21:04:44     LOG [LoggerInterceptor.name] Request: [GET] /items/26
query: SELECT * FROM `items` `items` WHERE ( `items`.`id` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: [26]
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt, `categories`.`deleted_at` AS deletedAt FROM `categories` `categories` INNER JOIN `item_categories` `item_categories` ON  `categories`.`id` = `item_categories`.`category_id` AND `item_categories`.`deleted_at` IS NULL WHERE ( `item_categories`.`item_id` = ? AND `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) -- PARAMETERS: [26]
[Nest] 66770  - 2025/06/29 21:04:44     LOG [LoggerInterceptor.name] Response: [GET] /items/26 7ms - {"id":26,"name":"オフィスチェア","quantity":3,"description":"作業するときによく利用し、リクライニングもできる","itemCategories":[{"id":4,"name":"家具","description":"家具に関するカテゴリ","createdAt":"2025-04-29T14:08:13.000Z","updatedAt":"2025-04-29T14:08:13.000Z"}]}
```
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->