### PR TITLE
feat：物品を削除したとき、在庫情報にも論理削除されるようにイベントを流す

### DIFF
--- a/src/application/services/item/events/item.deleted.event.publisher.interface.ts
+++ b/src/application/services/item/events/item.deleted.event.publisher.interface.ts
@@ -1,0 +1,16 @@
+import { Observable } from 'rxjs';
+
+export interface ItemDeletedEvent {
+  id: number;
+  name: string;
+  quantity: number;
+  description: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date;
+  categoryIds: number[];
+}
+
+export interface ItemDeletedEventPublisherInterface {
+  publishItemDeletedEvent(event: ItemDeletedEvent): Observable<void>;
+}

--- a/src/infrastructure/datasources/stocks/stocks.datasource.ts
+++ b/src/infrastructure/datasources/stocks/stocks.datasource.ts
@@ -161,4 +161,30 @@ export class StocksDatasource {
         .execute()
     ).pipe(map(() => undefined));
   }
+
+  /**
+   * 物品IDをを指定して在庫情報を論理削除
+   * @param itemId - 対象の物品ID
+   * @returns Observable<void>
+   */
+  deletedByItemId(itemId: number): Observable<void> {
+    const now = new Date();
+    return from(
+      this.dataSource
+        .getRepository(Stocks)
+        .createQueryBuilder('stocks')
+        .update(Stocks)
+        .set({
+          updatedAt: now,
+          deletedAt: now,
+        })
+        .where('item_id = :itemId AND deleted_at IS NULL', { itemId })
+        .execute()
+    ).pipe(
+      map((result) => {
+        console.log(`[StocksDatasource] Executed query with result:`, result);
+        return undefined;
+      })
+    );
+  }
 }

--- a/src/infrastructure/messaging/rabbitmq/publisher/item.deleted.event.publisher.ts
+++ b/src/infrastructure/messaging/rabbitmq/publisher/item.deleted.event.publisher.ts
@@ -1,0 +1,37 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
+import { Observable } from 'rxjs';
+import {
+  ItemDeletedEvent,
+  ItemDeletedEventPublisherInterface,
+} from '../../../../application/services/item/events/item.deleted.event.publisher.interface';
+
+@Injectable()
+export class RabbitMQItemDeletedEventPublisher
+  implements ItemDeletedEventPublisherInterface
+{
+  private readonly logger = new Logger(RabbitMQItemDeletedEventPublisher.name);
+
+  constructor(private readonly amqpConnection: AmqpConnection) {}
+
+  publishItemDeletedEvent(event: ItemDeletedEvent): Observable<void> {
+    return new Observable((subscriber) => {
+      this.amqpConnection
+        .publish('stock.exchange', 'stock.item.deleted', event)
+        .then(() => {
+          this.logger.log(
+            `Item deleted event published successfully for item ID: ${event.id}`
+          );
+          subscriber.next();
+          subscriber.complete();
+        })
+        .catch((error) => {
+          this.logger.error(
+            `Failed to publish item deleted event for item ID: ${event.id}`,
+            error
+          );
+          subscriber.error(error);
+        });
+    });
+  }
+}

--- a/src/infrastructure/messaging/rabbitmq/subscriber/item.deleted.event.subscriber.ts
+++ b/src/infrastructure/messaging/rabbitmq/subscriber/item.deleted.event.subscriber.ts
@@ -1,0 +1,35 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RabbitSubscribe } from '@golevelup/nestjs-rabbitmq';
+import { Observable, tap } from 'rxjs';
+import { StocksDatasource } from '../../../datasources/stocks/stocks.datasource';
+import { ItemDeletedEvent } from '../../../../application/services/item/events/item.deleted.event.publisher.interface';
+
+@Injectable()
+export class ItemDeletedEventSubscriber {
+  private readonly logger = new Logger(ItemDeletedEventSubscriber.name);
+
+  constructor(private readonly stocksDatasource: StocksDatasource) {}
+
+  @RabbitSubscribe({
+    exchange: 'stock.exchange',
+    routingKey: 'stock.item.deleted',
+    queue: 'stock.item.deleted.queue',
+  })
+  handleItemDeleted(event: ItemDeletedEvent): Observable<void> {
+    this.logger.log(`Received item deleted event for item ID: ${event.id}`);
+
+    return this.stocksDatasource.deletedByItemId(event.id).pipe(
+      tap({
+        next: () =>
+          this.logger.log(
+            `Successfully updated stock for deleted item ID: ${event.id}`
+          ),
+        error: (error) =>
+          this.logger.error(
+            `Error updating stock for deleted item ID: ${event.id}`,
+            error
+          ),
+      })
+    );
+  }
+}

--- a/src/presentation/controllers/item/item.controller.spec.ts
+++ b/src/presentation/controllers/item/item.controller.spec.ts
@@ -154,6 +154,12 @@ describe('ItemController', () => {
           },
         },
         {
+          provide: 'ItemDeletedEventPublisherInterface',
+          useValue: {
+            publishItemDeletedEvent: jest.fn(() => of(undefined)),
+          },
+        },
+        {
           provide: Logger,
           useValue: {
             log: jest.fn(),

--- a/src/presentation/modules/items.module.ts
+++ b/src/presentation/modules/items.module.ts
@@ -16,9 +16,11 @@ import { RabbitMQModule } from './rabbitmq.module';
 import { RabbitMQItemCreatedEventPublisher } from '../../infrastructure/messaging/rabbitmq/publisher/item.created.event.publisher';
 import { RabbitMQItemUpdatedEventPublisher } from '../../infrastructure/messaging/rabbitmq/publisher/item.updated.event.publisher';
 import { RabbitMQItemQuantityUpdatedEventPublisher } from '../../infrastructure/messaging/rabbitmq/publisher/item.quantity.updated.event.publisher';
+import { RabbitMQItemDeletedEventPublisher } from '../../infrastructure/messaging/rabbitmq/publisher/item.deleted.event.publisher';
 import { ItemCreatedEventSubscriber } from '../../infrastructure/messaging/rabbitmq/subscriber/item.created.event.subscriber';
 import { ItemUpdatedEventSubscriber } from '../../infrastructure/messaging/rabbitmq/subscriber/item.updated.event.subscriber';
 import { ItemQuantityUpdatedEventSubscriber } from '../../infrastructure/messaging/rabbitmq/subscriber/item.quantity.updated.event.subscriber';
+import { ItemDeletedEventSubscriber } from '../../infrastructure/messaging/rabbitmq/subscriber/item.deleted.event.subscriber';
 import { StocksModule } from './stocks.module';
 import { UpdateItemQuantityService } from '../../application/services/item/update.item.quantity.service';
 
@@ -37,6 +39,7 @@ import { UpdateItemQuantityService } from '../../application/services/item/updat
     ItemCreatedEventSubscriber,
     ItemUpdatedEventSubscriber,
     ItemQuantityUpdatedEventSubscriber,
+    ItemDeletedEventSubscriber,
     {
       provide: 'ItemCreatedEventPublisherInterface',
       useClass: RabbitMQItemCreatedEventPublisher,
@@ -48,6 +51,10 @@ import { UpdateItemQuantityService } from '../../application/services/item/updat
     {
       provide: 'ItemQuantityUpdatedEventPublisherInterface',
       useClass: RabbitMQItemQuantityUpdatedEventPublisher,
+    },
+    {
+      provide: 'ItemDeletedEventPublisherInterface',
+      useClass: RabbitMQItemDeletedEventPublisher,
     },
     {
       provide: 'ItemListServiceInterface',


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#85 
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- クエリの追加
- pub/subの追加
- 単体テストの修正

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

## 動作したときのスクリーンショット
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
```
Nest] 2709  - 2025/08/02 23:21:59     LOG [LoggerInterceptor.name] Request: [DELETE] /items/29
[Nest] 2709  - 2025/08/02 23:21:59     LOG [ItemDeleteService] Starting delete for item with ID: 29
query: SELECT * FROM `items` `items` WHERE ( `items`.`id` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: [29]
query: SELECT category_id AS `id` FROM `item_categories` `item_categories` WHERE ( `item_categories`.`item_id` = ? ) AND ( `item_categories`.`deleted_at` IS NULL ) -- PARAMETERS: [29]
query: UPDATE `items` SET `updated_at` = ?, `deleted_at` = ? WHERE `id` = ? -- PARAMETERS: ["2025-08-02T14:21:59.405Z","2025-08-02T14:21:59.405Z",29]
Publishing item deleted event: {
  id: 29,
  name: 'Python入門だよ',
  quantity: 11,
  description: 'Pythonの本だよ',
  createdAt: undefined,
  updatedAt: undefined,
  deletedAt: 2025-08-02T14:21:59.405Z,
  categoryIds: [ 1 ]
}
[Nest] 2709  - 2025/08/02 23:21:59     LOG [LoggerInterceptor.name] Request: [undefined] undefined
Item deleted event published successfully
[Nest] 2709  - 2025/08/02 23:21:59     LOG [ItemDeleteService] Deleted item with ID: 29 and published event
[Nest] 2709  - 2025/08/02 23:21:59     LOG [LoggerInterceptor.name] Response: [DELETE] /items/29 39ms - {"id":29,"name":"Python入門だよ","quantity":11,"description":"Pythonの本だよ","deletedAt":"2025-08-02T14:21:59.405Z"}
[Nest] 2709  - 2025/08/02 23:21:59     LOG [ItemDeletedEventSubscriber] Received item deleted event for item ID: 29
query: UPDATE `stocks` SET `quantity` = ?, `updated_at` = ?, `deleted_at` = ? WHERE `item_id` = ? AND `deleted_at` IS NULL -- PARAMETERS: [0,"2025-08-02T14:21:59.416Z","2025-08-02T14:21:59.416Z",29]
[StocksDatasource] Executed query with result: UpdateResult { generatedMaps: [], raw: [], affected: 1 }
[Nest] 2709  - 2025/08/02 23:21:59     LOG [ItemDeletedEventSubscriber] Successfully updated stock for deleted item ID: 29
[Nest] 2709  - 2025/08/02 23:21:59     LOG [LoggerInterceptor.name] Response: [undefined] undefined 6ms - undefined
```
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->