### PR TITLE
feat：作成イベントにも在庫ステータスが対応できるように変更

### DIFF
--- a/src/application/dto/input/stock/stock.register.input.dto.ts
+++ b/src/application/dto/input/stock/stock.register.input.dto.ts
@@ -1,0 +1,122 @@
+import { InputDto } from '../input.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsInt,
+  IsString,
+  IsArray,
+  IsDateString,
+  IsEnum,
+} from 'class-validator';
+import { Expose, Type } from 'class-transformer';
+import {
+  EventSource,
+  EVENT_SOURCES,
+} from '../../../services/stock/constants/event.sources';
+
+/**
+ * 在庫登録を行う際のリクエスト情報を表すDTO
+ * ItemCreatedEventとEventSourceの情報を含む
+ */
+export class StockRegisterInputDto implements InputDto {
+  @ApiProperty({
+    example: 1,
+    description: 'アイテムID',
+    type: Number,
+  })
+  @IsNotEmpty()
+  @IsInt()
+  @Expose({ name: 'id' })
+  id: number;
+
+  @ApiProperty({
+    example: 'テストアイテム',
+    description: 'アイテム名',
+    type: String,
+  })
+  @IsNotEmpty()
+  @IsString()
+  @Expose({ name: 'name' })
+  name: string;
+
+  @ApiProperty({
+    example: 10,
+    description: '数量',
+    type: Number,
+  })
+  @IsNotEmpty()
+  @IsInt()
+  @Expose({ name: 'quantity' })
+  quantity: number;
+
+  @ApiProperty({
+    example: 'テストアイテムの説明',
+    description: 'アイテムの説明',
+    type: String,
+  })
+  @IsOptional()
+  @IsString()
+  @Expose({ name: 'description' })
+  description?: string;
+
+  @ApiProperty({
+    example: '2024-01-01T00:00:00.000Z',
+    description: '作成日時',
+    type: String,
+  })
+  @IsNotEmpty()
+  @IsDateString()
+  @Type(() => Date)
+  @Expose({ name: 'created_at' })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: '2024-01-01T00:00:00.000Z',
+    description: '更新日時',
+    type: String,
+  })
+  @IsNotEmpty()
+  @IsDateString()
+  @Type(() => Date)
+  @Expose({ name: 'updated_at' })
+  updatedAt: Date;
+
+  @ApiProperty({
+    example: [1, 2],
+    description: 'カテゴリーIDの配列',
+    type: [Number],
+  })
+  @IsNotEmpty()
+  @IsArray()
+  @IsInt({ each: true })
+  @Expose({ name: 'category_ids' })
+  categoryIds: number[];
+
+  @ApiProperty({
+    example: 'item.created',
+    description: 'イベントソース',
+    enum: Object.values(EVENT_SOURCES),
+    type: String,
+  })
+  @IsNotEmpty()
+  @IsEnum(Object.values(EVENT_SOURCES))
+  @Expose({ name: 'event_source' })
+  eventSource: EventSource;
+
+  /**
+   * ItemCreatedEventオブジェクトに変換する
+   * @returns ItemCreatedEvent
+   */
+  toItemCreatedEvent() {
+    return {
+      id: this.id,
+      name: this.name,
+      quantity: this.quantity,
+      description: this.description || '',
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+      categoryIds: this.categoryIds,
+    };
+  }
+}

--- a/src/application/dto/output/stock/stock.list.output.dto.ts
+++ b/src/application/dto/output/stock/stock.list.output.dto.ts
@@ -51,7 +51,7 @@ export class StockResults {
     type: Number,
   })
   @Expose({ name: 'id' })
-  id: number;
+  id: number | string;
 
   @ApiProperty({
     example: 10,

--- a/src/application/dto/output/stock/stock.register.output.builder.spec.ts
+++ b/src/application/dto/output/stock/stock.register.output.builder.spec.ts
@@ -1,0 +1,303 @@
+import { StockRegisterOutputDtoBuilder } from './stock.register.output.builder';
+import { StockRegisterOutputDto } from './stock.register.output.dto';
+import { Stock } from '../../../../domain/inventory/stocks/entities/stock.entity';
+import { StockStatus } from '../../../../domain/inventory/stocks/entities/stock.status.entity';
+import { Items } from '../../../../infrastructure/orm/entities/items.entity';
+import { Quantity } from '../../../../domain/inventory/items/value-objects/quantity';
+
+describe('StockRegisterOutputDtoBuilder', () => {
+  let builder: StockRegisterOutputDtoBuilder;
+
+  // モックデータの作成
+  const mockQuantity = Quantity.of(10);
+  const mockStockStatus = new StockStatus(
+    1,
+    'available',
+    'Available status',
+    new Date('2024-01-01'),
+    new Date('2024-01-01'),
+    null
+  );
+
+  const mockStock = new Stock(
+    123, // DB ID (永続化済み)
+    mockQuantity,
+    'Test stock description',
+    new Date('2024-01-01T10:00:00Z'),
+    new Date('2024-01-01T11:00:00Z'),
+    null,
+    1, // itemId
+    mockStockStatus
+  );
+
+  const mockItem: Items = {
+    id: 1,
+    name: 'Test Item',
+    quantity: 10,
+    description: 'Test Item Description',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    deletedAt: null,
+    itemCategories: [],
+  };
+
+  describe('constructor', () => {
+    it('Stockエンティティのみで初期化できること', () => {
+      builder = new StockRegisterOutputDtoBuilder(mockStock);
+
+      expect(builder).toBeDefined();
+    });
+
+    it('StockエンティティとItemエンティティで初期化できること', () => {
+      builder = new StockRegisterOutputDtoBuilder(mockStock, mockItem);
+
+      expect(builder).toBeDefined();
+    });
+
+    it('Itemエンティティがnullでも初期化できること', () => {
+      builder = new StockRegisterOutputDtoBuilder(mockStock, null);
+
+      expect(builder).toBeDefined();
+    });
+
+    it('Itemエンティティが未指定でも初期化できること', () => {
+      builder = new StockRegisterOutputDtoBuilder(mockStock);
+
+      expect(builder).toBeDefined();
+    });
+  });
+
+  describe('build', () => {
+    it('完全なデータでOutput DTOを正しく構築すること', () => {
+      // Arrange
+      builder = new StockRegisterOutputDtoBuilder(mockStock, mockItem);
+
+      // Act
+      const result = builder.build();
+
+      // Assert
+      expect(result).toBeInstanceOf(StockRegisterOutputDto);
+      expect(result.id).toBe(123);
+      expect(result.quantity).toBe(10);
+      expect(result.description).toBe('Test stock description');
+      expect(result.createdAt).toEqual(new Date('2024-01-01T10:00:00Z'));
+      expect(result.updatedAt).toEqual(new Date('2024-01-01T11:00:00Z'));
+
+      // Item情報の検証
+      expect(result.item).toEqual({
+        id: 1,
+        name: 'Test Item',
+      });
+
+      // Status情報の検証
+      expect(result.status).toEqual({
+        id: 1,
+        name: 'available',
+        description: 'Available status',
+      });
+    });
+
+    it('Itemがnullの場合、itemフィールドがnullになること', () => {
+      // Arrange
+      builder = new StockRegisterOutputDtoBuilder(mockStock, null);
+
+      // Act
+      const result = builder.build();
+
+      // Assert
+      expect(result).toBeInstanceOf(StockRegisterOutputDto);
+      expect(result.id).toBe(123);
+      expect(result.quantity).toBe(10);
+      expect(result.description).toBe('Test stock description');
+      expect(result.item).toBeNull();
+
+      // Statusは正常に設定される
+      expect(result.status).toEqual({
+        id: 1,
+        name: 'available',
+        description: 'Available status',
+      });
+    });
+
+    it('Itemが未指定の場合、itemフィールドがnullになること', () => {
+      // Arrange
+      builder = new StockRegisterOutputDtoBuilder(mockStock);
+
+      // Act
+      const result = builder.build();
+
+      // Assert
+      expect(result).toBeInstanceOf(StockRegisterOutputDto);
+      expect(result.item).toBeNull();
+    });
+
+    it('Stockのstatusがnullの場合、statusフィールドがnullになること', () => {
+      // Arrange
+      const stockWithoutStatus = new Stock(
+        456,
+        mockQuantity,
+        'Test stock without status',
+        new Date('2024-01-01T10:00:00Z'),
+        new Date('2024-01-01T11:00:00Z'),
+        null,
+        1,
+        null // status is null
+      );
+      builder = new StockRegisterOutputDtoBuilder(stockWithoutStatus, mockItem);
+
+      // Act
+      const result = builder.build();
+
+      // Assert
+      expect(result).toBeInstanceOf(StockRegisterOutputDto);
+      expect(result.id).toBe(456);
+      expect(result.status).toBeNull();
+
+      // 他のフィールドは正常に設定される
+      expect(result.item).toEqual({
+        id: 1,
+        name: 'Test Item',
+      });
+    });
+
+    it('UUID（string）のIDでも正しく構築できること', () => {
+      // Arrange
+      const stockWithUUID = new Stock(
+        'uuid-123-456-789',
+        mockQuantity,
+        'Test stock with UUID',
+        new Date('2024-01-01T10:00:00Z'),
+        new Date('2024-01-01T11:00:00Z'),
+        null,
+        1,
+        mockStockStatus
+      );
+      builder = new StockRegisterOutputDtoBuilder(stockWithUUID, mockItem);
+
+      // Act
+      const result = builder.build();
+
+      // Assert
+      expect(result).toBeInstanceOf(StockRegisterOutputDto);
+      expect(result.id).toBe('uuid-123-456-789');
+      expect(result.quantity).toBe(10);
+      expect(result.description).toBe('Test stock with UUID');
+    });
+
+    it('空の説明でも正しく構築できること', () => {
+      // Arrange
+      const stockWithEmptyDescription = new Stock(
+        789,
+        mockQuantity,
+        '', // empty description
+        new Date('2024-01-01T10:00:00Z'),
+        new Date('2024-01-01T11:00:00Z'),
+        null,
+        1,
+        mockStockStatus
+      );
+      builder = new StockRegisterOutputDtoBuilder(
+        stockWithEmptyDescription,
+        mockItem
+      );
+
+      // Act
+      const result = builder.build();
+
+      // Assert
+      expect(result).toBeInstanceOf(StockRegisterOutputDto);
+      expect(result.description).toBe('');
+    });
+
+    it('複数回buildを呼び出しても同じ結果を返すこと', () => {
+      // Arrange
+      builder = new StockRegisterOutputDtoBuilder(mockStock, mockItem);
+
+      // Act
+      const result1 = builder.build();
+      const result2 = builder.build();
+
+      // Assert
+      expect(result1).toEqual(result2);
+      expect(result1).not.toBe(result2); // 異なるインスタンス
+    });
+  });
+
+  describe('edge cases', () => {
+    it('最小数量(1)で正しく構築できること', () => {
+      // Arrange
+      const minQuantity = Quantity.of(1);
+      const stockWithMinQuantity = new Stock(
+        999,
+        minQuantity,
+        'Test stock with min quantity',
+        new Date('2024-01-01T10:00:00Z'),
+        new Date('2024-01-01T11:00:00Z'),
+        null,
+        1,
+        mockStockStatus
+      );
+      builder = new StockRegisterOutputDtoBuilder(
+        stockWithMinQuantity,
+        mockItem
+      );
+
+      // Act
+      const result = builder.build();
+
+      // Assert
+      expect(result.quantity).toBe(1);
+    });
+
+    it('最大数量(100)で正しく構築できること', () => {
+      // Arrange
+      const maxQuantity = Quantity.of(100);
+      const stockWithMaxQuantity = new Stock(
+        1000,
+        maxQuantity,
+        'Test stock with max quantity',
+        new Date('2024-01-01T10:00:00Z'),
+        new Date('2024-01-01T11:00:00Z'),
+        null,
+        1,
+        mockStockStatus
+      );
+      builder = new StockRegisterOutputDtoBuilder(
+        stockWithMaxQuantity,
+        mockItem
+      );
+
+      // Act
+      const result = builder.build();
+
+      // Assert
+      expect(result.quantity).toBe(100);
+    });
+
+    it('長い説明文でも正しく構築できること', () => {
+      // Arrange
+      const longDescription = 'This is a very long description '.repeat(10);
+      const stockWithLongDescription = new Stock(
+        1001,
+        mockQuantity,
+        longDescription,
+        new Date('2024-01-01T10:00:00Z'),
+        new Date('2024-01-01T11:00:00Z'),
+        null,
+        1,
+        mockStockStatus
+      );
+      builder = new StockRegisterOutputDtoBuilder(
+        stockWithLongDescription,
+        mockItem
+      );
+
+      // Act
+      const result = builder.build();
+
+      // Assert
+      expect(result.description).toBe(longDescription);
+      expect(result.description.length).toBeGreaterThan(100);
+    });
+  });
+});

--- a/src/application/dto/output/stock/stock.register.output.builder.ts
+++ b/src/application/dto/output/stock/stock.register.output.builder.ts
@@ -1,0 +1,43 @@
+import { OutputBuilder } from '../../output/output.builder';
+import { StockRegisterOutputDto } from './stock.register.output.dto';
+import { Stock } from '../../../../domain/inventory/stocks/entities/stock.entity';
+import { Items } from '../../../../infrastructure/orm/entities/items.entity';
+
+export class StockRegisterOutputDtoBuilder
+  implements OutputBuilder<StockRegisterOutputDto>
+{
+  private _stock: Stock;
+  private _item: Items | null;
+
+  constructor(stock: Stock, item?: Items | null) {
+    this._stock = stock;
+    this._item = item || null;
+  }
+
+  build(): StockRegisterOutputDto {
+    const output = new StockRegisterOutputDto();
+
+    output.id = this._stock.id;
+    output.quantity = this._stock.quantity.value();
+    output.description = this._stock.description;
+    output.createdAt = this._stock.createdAt;
+    output.updatedAt = this._stock.updatedAt;
+
+    output.item = this._item
+      ? {
+          id: this._item.id,
+          name: this._item.name,
+        }
+      : null;
+
+    output.status = this._stock.status
+      ? {
+          id: this._stock.status.id,
+          name: this._stock.status.name,
+          description: this._stock.status.description,
+        }
+      : null;
+
+    return output;
+  }
+}

--- a/src/application/dto/output/stock/stock.register.output.dto.ts
+++ b/src/application/dto/output/stock/stock.register.output.dto.ts
@@ -1,0 +1,101 @@
+import { OutputDto } from '../../output/output.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose, Type } from 'class-transformer';
+
+export class StockItem {
+  @ApiProperty({
+    example: 1,
+    description: '物品ID',
+    type: Number,
+  })
+  @Expose({ name: 'id' })
+  id: number;
+
+  @ApiProperty({
+    example: 'テスト物品',
+    description: '物品名',
+    type: String,
+  })
+  @Expose({ name: 'name' })
+  name: string;
+}
+
+export class StockStatus {
+  @ApiProperty({
+    example: 1,
+    description: '在庫ステータスID',
+    type: Number,
+  })
+  id: number;
+
+  @ApiProperty({
+    example: '利用可能',
+    description: '在庫ステータス名',
+    type: String,
+  })
+  name: string;
+
+  //description
+  @ApiProperty({
+    example: 'この在庫は利用可能です。',
+    description: '在庫ステータスの説明',
+    type: String,
+  })
+  description: string;
+}
+
+export class StockRegisterOutputDto implements OutputDto {
+  @ApiProperty()
+  @Expose()
+  id: number | string;
+
+  @ApiProperty()
+  @Expose()
+  quantity: number;
+
+  @ApiProperty()
+  @Expose()
+  description: string;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: '作成日時',
+    type: Date,
+  })
+  @Expose({ name: 'created_at' })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: '2021-01-01T00:00:00.000Z',
+    description: '更新日時',
+    type: Date,
+  })
+  @Expose({ name: 'updated_at' })
+  updatedAt: Date;
+
+  @Type(() => StockItem)
+  @ApiProperty({
+    example: {
+      id: 1,
+      name: 'テスト物品',
+    },
+    description: '関連する物品情報',
+    type: StockItem,
+    nullable: true,
+  })
+  @Expose({ name: 'item' })
+  item: StockItem | null;
+
+  @Type(() => StockStatus)
+  @ApiProperty({
+    example: {
+      id: 1,
+      name: '利用可能',
+      description: 'この在庫は利用可能です。',
+    },
+    description: '関連する在庫ステータス情報',
+    type: StockStatus,
+  })
+  @Expose({ name: 'status' })
+  status: StockStatus;
+}

--- a/src/application/services/stock/constants/event.sources.ts
+++ b/src/application/services/stock/constants/event.sources.ts
@@ -1,0 +1,39 @@
+/**
+ * イベントソースのUnion型定義
+ */
+export type EventSource =
+  | 'item.created'
+  | 'item.updated'
+  | 'item.deleted'
+  | 'item.restored';
+
+/**
+ * イベントソース定数
+ * RabbitMQのルーティングキーなどで使用される
+ */
+export const EVENT_SOURCES = {
+  ITEM_CREATED: 'item.created',
+  ITEM_UPDATED: 'item.updated',
+  ITEM_DELETED: 'item.deleted',
+  ITEM_RESTORED: 'item.restored',
+} as const;
+
+/**
+ * イベントソースから在庫ステータスへのマッピング型定義
+ */
+export type EventSourceToStatusMap = {
+  readonly 'item.created': 'available';
+  readonly 'item.updated': 'available';
+  readonly 'item.restored': 'adjusting';
+  readonly 'item.deleted': 'stopped';
+};
+
+/**
+ * イベントソースから在庫ステータスへのマッピングオブジェクト
+ */
+export const EVENT_SOURCE_TO_STATUS: EventSourceToStatusMap = {
+  'item.created': 'available',
+  'item.updated': 'available',
+  'item.restored': 'adjusting',
+  'item.deleted': 'stopped',
+} as const;

--- a/src/application/services/stock/events/stock.created.event.subscriber.interface.ts
+++ b/src/application/services/stock/events/stock.created.event.subscriber.interface.ts
@@ -1,8 +1,9 @@
 import { Observable } from 'rxjs';
 import { ItemCreatedEvent } from '../../item/events/item.created.event.publisher.interface';
+import { StockRegisterOutputDto } from '../../../dto/output/stock/stock.register.output.dto';
 import { ApplicationEventHandler } from '../../application.event.handler';
 
 export interface StockCreatedEventSubscriberInterface
-  extends ApplicationEventHandler<ItemCreatedEvent, void> {
-  handle(event: ItemCreatedEvent): Observable<void>;
+  extends ApplicationEventHandler<ItemCreatedEvent, StockRegisterOutputDto> {
+  handle(event: ItemCreatedEvent): Observable<StockRegisterOutputDto>;
 }

--- a/src/application/services/stock/events/stock.created.event.subscriber.service.ts
+++ b/src/application/services/stock/events/stock.created.event.subscriber.service.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
-import { Observable, tap, map } from 'rxjs';
-import {
-  StocksDatasourceInterface,
-  STOCKS_DATASOURCE_TOKEN,
-} from '../../../../infrastructure/datasources/stocks/stocks.datasource.interface';
+import { Observable } from 'rxjs';
+import { StockRegisterServiceInterface } from '../stock.register.interface';
 import { ItemCreatedEvent } from '../../item/events/item.created.event.publisher.interface';
 import { StockCreatedEventSubscriberInterface } from './stock.created.event.subscriber.interface';
+import { StockRegisterOutputDto } from '../../../dto/output/stock/stock.register.output.dto';
+import { StockRegisterInputDto } from '../../../dto/input/stock/stock.register.input.dto';
+import { EVENT_SOURCES } from '../constants/event.sources';
 
 @Injectable()
 export class StockCreatedEventSubscriberService
@@ -14,24 +14,24 @@ export class StockCreatedEventSubscriberService
   private readonly logger = new Logger(StockCreatedEventSubscriberService.name);
 
   constructor(
-    @Inject(STOCKS_DATASOURCE_TOKEN)
-    private readonly stocksDatasource: StocksDatasourceInterface
+    @Inject('StockRegisterServiceInterface')
+    private readonly stockRegisterService: StockRegisterServiceInterface
   ) {}
 
-  handle(event: ItemCreatedEvent): Observable<void> {
-    this.logger.log(`Handling stock create for item ID: ${event.id}`);
-    return this.stocksDatasource
-      .createStockQuantityByItemId(event.id, event.quantity, event.description)
-      .pipe(
-        tap({
-          next: () =>
-            this.logger.log(`Stock created/updated for item ID: ${event.id}`),
-          error: (error) =>
-            this.logger.error(
-              `Failed to create/update stock for item ${event.id}: ${error.message}`
-            ),
-        }),
-        map(() => void 0)
-      );
+  handle(event: ItemCreatedEvent): Observable<StockRegisterOutputDto> {
+    this.logger.log(`Handling stock create event for item ID: ${event.id}`);
+
+    // EventをInput DTOに変換
+    const inputDto = new StockRegisterInputDto();
+    inputDto.id = event.id;
+    inputDto.name = event.name;
+    inputDto.quantity = event.quantity;
+    inputDto.description = event.description;
+    inputDto.createdAt = event.createdAt;
+    inputDto.updatedAt = event.updatedAt;
+    inputDto.categoryIds = event.categoryIds;
+    inputDto.eventSource = EVENT_SOURCES.ITEM_CREATED;
+
+    return this.stockRegisterService.service(inputDto);
   }
 }

--- a/src/application/services/stock/stock.register.interface.ts
+++ b/src/application/services/stock/stock.register.interface.ts
@@ -1,0 +1,15 @@
+import { StockRegisterOutputDto } from '../../dto/output/stock/stock.register.output.dto';
+import { StockRegisterInputDto } from '../../dto/input/stock/stock.register.input.dto';
+import { ApplicationService } from '../application.service';
+import { ItemsDatasourceInterface } from 'src/infrastructure/datasources/items/items.datasource.interface';
+import { StocksDatasourceInterface } from 'src/infrastructure/datasources/stocks/stocks.datasource.interface';
+
+/**
+ * 在庫登録サービスのインターフェース
+ * 在庫登録Input DTOを受け取って在庫を登録し、適切なステータスを設定する
+ */
+export interface StockRegisterServiceInterface
+  extends ApplicationService<StockRegisterInputDto, StockRegisterOutputDto> {
+  stocksDatasource: StocksDatasourceInterface;
+  itemsDatasource: ItemsDatasourceInterface;
+}

--- a/src/application/services/stock/stock.register.service.spec.ts
+++ b/src/application/services/stock/stock.register.service.spec.ts
@@ -1,0 +1,301 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { of, throwError } from 'rxjs';
+import { NotFoundException } from '@nestjs/common';
+import { StockRegisterService } from './stock.register.service';
+import { StockRegisterInputDto } from '../../dto/input/stock/stock.register.input.dto';
+import { StockRegisterOutputDto } from '../../dto/output/stock/stock.register.output.dto';
+import {
+  ITEMS_DATASOURCE_TOKEN,
+  ItemsDatasourceInterface,
+} from '../../../infrastructure/datasources/items/items.datasource.interface';
+import {
+  STOCKS_DATASOURCE_TOKEN,
+  StocksDatasourceInterface,
+} from '../../../infrastructure/datasources/stocks/stocks.datasource.interface';
+import { EVENT_SOURCES, EventSource } from './constants/event.sources';
+import { Items } from '../../../infrastructure/orm/entities/items.entity';
+import { StockStatuses } from '../../../infrastructure/orm/entities/stock.statuses.entity';
+import { Stock } from '../../../domain/inventory/stocks/entities/stock.entity';
+import { StockStatus } from '../../../domain/inventory/stocks/entities/stock.status.entity';
+import { Quantity } from '../../../domain/inventory/items/value-objects/quantity';
+
+describe('StockRegisterService', () => {
+  let stockRegisterService: StockRegisterService;
+  let itemsDatasource: jest.Mocked<ItemsDatasourceInterface>;
+  let stocksDatasource: jest.Mocked<StocksDatasourceInterface>;
+
+  const mockItem: Items = {
+    id: 1,
+    name: 'Test Item',
+    quantity: 10,
+    description: 'Test Description',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    deletedAt: null,
+    itemCategories: [],
+  };
+
+  const mockStockStatus: StockStatuses = {
+    id: 1,
+    name: 'available',
+    description: 'Available status',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    deletedAt: null,
+    stocks: [],
+  };
+
+  const mockInputDto: StockRegisterInputDto = {
+    id: 1,
+    name: 'Test Item',
+    quantity: 10,
+    description: 'Test Description',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    categoryIds: [1, 2],
+    eventSource: EVENT_SOURCES.ITEM_CREATED,
+    toItemCreatedEvent: jest.fn().mockReturnValue({
+      id: 1,
+      name: 'Test Item',
+      quantity: 10,
+      description: 'Test Description',
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+      categoryIds: [1, 2],
+    }),
+  };
+
+  beforeEach(async () => {
+    const mockItemsDatasource = {
+      findItemById: jest.fn(),
+    };
+
+    const mockStocksDatasource = {
+      getStatusByName: jest.fn(),
+      createStockWithStatusIdInTransaction: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StockRegisterService,
+        {
+          provide: ITEMS_DATASOURCE_TOKEN,
+          useValue: mockItemsDatasource,
+        },
+        {
+          provide: STOCKS_DATASOURCE_TOKEN,
+          useValue: mockStocksDatasource,
+        },
+      ],
+    }).compile();
+
+    stockRegisterService =
+      module.get<StockRegisterService>(StockRegisterService);
+    itemsDatasource = module.get(ITEMS_DATASOURCE_TOKEN);
+    stocksDatasource = module.get(STOCKS_DATASOURCE_TOKEN);
+  });
+
+  it('should be defined', () => {
+    expect(stockRegisterService).toBeDefined();
+  });
+
+  describe('service', () => {
+    it('在庫登録が正常に完了する場合、Output DTOを返すこと', (done) => {
+      const mockStockId = 123;
+
+      itemsDatasource.findItemById.mockReturnValue(of(mockItem));
+      stocksDatasource.getStatusByName.mockReturnValue(of(mockStockStatus));
+      stocksDatasource.createStockWithStatusIdInTransaction.mockReturnValue(
+        of(mockStockId)
+      );
+
+      stockRegisterService.service(mockInputDto).subscribe({
+        next: (result: StockRegisterOutputDto) => {
+          expect(result).toBeDefined();
+          expect(result.id).toBe(mockStockId);
+          expect(result.quantity).toBe(10);
+          expect(result.description).toBe('Test Description');
+          expect(result.item).toEqual({
+            id: 1,
+            name: 'Test Item',
+          });
+          expect(result.status).toEqual({
+            id: 1,
+            name: 'available',
+            description: 'Available status',
+          });
+
+          expect(itemsDatasource.findItemById).toHaveBeenCalledWith(1);
+          expect(stocksDatasource.getStatusByName).toHaveBeenCalledWith(
+            'available'
+          );
+          expect(
+            stocksDatasource.createStockWithStatusIdInTransaction
+          ).toHaveBeenCalledWith(1, 10, 1, 'Test Description');
+
+          done();
+        },
+        error: done.fail,
+      });
+    });
+
+    it('不正なイベントソースの場合、エラーを投げること', (done) => {
+      const invalidInputDto = {
+        ...mockInputDto,
+        eventSource: 'invalid.source' as EventSource,
+        toItemCreatedEvent: jest.fn().mockReturnValue({
+          id: 1,
+          name: 'Test Item',
+          quantity: 10,
+          description: 'Test Description',
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-01'),
+          categoryIds: [1, 2],
+        }),
+      };
+
+      stockRegisterService.service(invalidInputDto).subscribe({
+        next: () => done.fail('Expected error but got success'),
+        error: (error: Error) => {
+          expect(error.message).toContain(
+            'Unknown event source: invalid.source'
+          );
+          done();
+        },
+      });
+    });
+
+    it('アイテムが見つからない場合、NotFoundException を投げること', (done) => {
+      itemsDatasource.findItemById.mockReturnValue(of(null));
+      stocksDatasource.getStatusByName.mockReturnValue(of(mockStockStatus));
+
+      stockRegisterService.service(mockInputDto).subscribe({
+        next: () => done.fail('Expected error but got success'),
+        error: (error: NotFoundException) => {
+          expect(error).toBeInstanceOf(NotFoundException);
+          expect(error.message).toBe('Item not found');
+          done();
+        },
+      });
+    });
+
+    it('ステータスが見つからない場合、NotFoundException を投げること', (done) => {
+      itemsDatasource.findItemById.mockReturnValue(of(mockItem));
+      stocksDatasource.getStatusByName.mockReturnValue(of(null));
+
+      stockRegisterService.service(mockInputDto).subscribe({
+        next: () => done.fail('Expected error but got success'),
+        error: (error: NotFoundException) => {
+          expect(error).toBeInstanceOf(NotFoundException);
+          expect(error.message).toBe('Stock status not found');
+          done();
+        },
+      });
+    });
+
+    it('永続化処理でエラーが発生した場合、エラーを伝播すること', (done) => {
+      const persistError = new Error('Database error');
+
+      itemsDatasource.findItemById.mockReturnValue(of(mockItem));
+      stocksDatasource.getStatusByName.mockReturnValue(of(mockStockStatus));
+      stocksDatasource.createStockWithStatusIdInTransaction.mockReturnValue(
+        throwError(() => persistError)
+      );
+
+      stockRegisterService.service(mockInputDto).subscribe({
+        next: () => done.fail('Expected error but got success'),
+        error: (error: Error) => {
+          expect(error).toBe(persistError);
+          done();
+        },
+      });
+    });
+  });
+
+  describe('determineStockStatus (private method)', () => {
+    it('正しいイベントソースに対して適切なステータス名を返すこと', () => {
+      const result = stockRegisterService['determineStockStatus'](
+        EVENT_SOURCES.ITEM_CREATED
+      );
+      expect(result).toBe('available');
+    });
+
+    it('不正なイベントソースに対してundefinedを返すこと', () => {
+      const result = stockRegisterService['determineStockStatus'](
+        'invalid.source' as EventSource
+      );
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('createStockEntity (private method)', () => {
+    it('正しいStock entityを作成すること', () => {
+      const event = {
+        id: 1,
+        quantity: 10,
+        description: 'Test Description',
+      };
+
+      const result = stockRegisterService['createStockEntity'](
+        mockItem,
+        mockStockStatus,
+        event
+      );
+
+      expect(result).toBeInstanceOf(Stock);
+      expect(result.quantity.value()).toBe(10);
+      expect(result.description).toBe('Test Description');
+      expect(result.itemId).toBe(1);
+      expect(result.status.name).toBe('available');
+    });
+
+    it('descriptionが空の場合、空文字を設定すること', () => {
+      const event = {
+        id: 1,
+        quantity: 10,
+        description: '',
+      };
+
+      const result = stockRegisterService['createStockEntity'](
+        mockItem,
+        mockStockStatus,
+        event
+      );
+
+      expect(result.description).toBe('');
+    });
+  });
+
+  describe('extractPersistenceData (private method)', () => {
+    it('Stock entityから永続化用データを正しく抽出すること', () => {
+      const mockQuantity = Quantity.of(10);
+      const mockStatus = new StockStatus(
+        1,
+        'available',
+        'Available status',
+        new Date('2024-01-01'),
+        new Date('2024-01-01'),
+        null
+      );
+      const mockStock = new Stock(
+        1,
+        mockQuantity,
+        'Test Description',
+        new Date('2024-01-01'),
+        new Date('2024-01-01'),
+        null,
+        1,
+        mockStatus
+      );
+
+      const result = stockRegisterService['extractPersistenceData'](mockStock);
+
+      expect(result).toEqual({
+        itemId: 1,
+        quantity: 10,
+        statusId: 1,
+        description: 'Test Description',
+      });
+    });
+  });
+});

--- a/src/application/services/stock/stock.register.service.ts
+++ b/src/application/services/stock/stock.register.service.ts
@@ -1,0 +1,242 @@
+import {
+  Observable,
+  tap,
+  switchMap,
+  map,
+  forkJoin,
+  throwError,
+  of,
+  filter,
+  defaultIfEmpty,
+  mergeMap,
+} from 'rxjs';
+import { Injectable, Logger, Inject, NotFoundException } from '@nestjs/common';
+import { StockRegisterServiceInterface } from './stock.register.interface';
+import { StockRegisterInputDto } from '../../dto/input/stock/stock.register.input.dto';
+import { ItemCreatedEvent } from '../item/events/item.created.event.publisher.interface';
+import {
+  ITEMS_DATASOURCE_TOKEN,
+  ItemsDatasourceInterface,
+} from '../../../infrastructure/datasources/items/items.datasource.interface';
+
+import {
+  StocksDatasourceInterface,
+  STOCKS_DATASOURCE_TOKEN,
+} from '../../../infrastructure/datasources/stocks/stocks.datasource.interface';
+import { EventSource, EVENT_SOURCE_TO_STATUS } from './constants/event.sources';
+import { Stock } from '../../../domain/inventory/stocks/entities/stock.entity';
+import { StockStatus } from '../../../domain/inventory/stocks/entities/stock.status.entity';
+import { Quantity } from '../../../domain/inventory/items/value-objects/quantity';
+import { StockRegisterOutputDto } from '../../dto/output/stock/stock.register.output.dto';
+import { StockRegisterOutputDtoBuilder } from '../../dto/output/stock/stock.register.output.builder';
+import {
+  ItemNotFoundOperator,
+  StockStatusNotFoundOperator,
+} from 'src/common/types/rxjs-operator.types';
+import { Items } from 'src/infrastructure/orm/entities/items.entity';
+import { StockStatuses } from 'src/infrastructure/orm/entities/stock.statuses.entity';
+
+@Injectable()
+export class StockRegisterService implements StockRegisterServiceInterface {
+  private readonly logger = new Logger(StockRegisterService.name);
+
+  constructor(
+    @Inject(STOCKS_DATASOURCE_TOKEN)
+    public readonly stocksDatasource: StocksDatasourceInterface,
+    @Inject(ITEMS_DATASOURCE_TOKEN)
+    public readonly itemsDatasource: ItemsDatasourceInterface
+  ) {}
+
+  /**
+   * Input DTOを使用して在庫を登録する
+   * @param inputDto - 在庫登録用Input DTO
+   * @returns StockRegisterOutputDto
+   */
+  service(inputDto: StockRegisterInputDto): Observable<StockRegisterOutputDto> {
+    const event = inputDto.toItemCreatedEvent();
+    const eventSource = inputDto.eventSource;
+
+    this.logger.log(
+      `Registering stock for item ID: ${event.id} from source: ${eventSource}`
+    );
+
+    return of(eventSource).pipe(
+      map((source) => this.determineStockStatus(source)),
+      this.throwIfInvalidEventSource(eventSource),
+      switchMap((statusName) =>
+        forkJoin({
+          item: this.itemsDatasource
+            .findItemById(event.id)
+            .pipe(this.throwIfItemNotFound()),
+          status: this.stocksDatasource
+            .getStatusByName(statusName)
+            .pipe(this.throwIfStockStatusesNotFound()),
+          statusName: of(statusName),
+        })
+      ),
+      switchMap(({ item, status, statusName }) => {
+        return of({ item, status, event }).pipe(
+          map(({ item, status, event }) =>
+            this.createStockEntity(item, status, event)
+          ),
+          tap((stockEntity) =>
+            this.logger.log(
+              `Created stock entity with UUID: ${stockEntity.id}, isPersisted: ${stockEntity.isPersisted()}`
+            )
+          ),
+          switchMap((stockEntity) =>
+            this.persistStockEntity(stockEntity).pipe(
+              map((persistedStockEntity) => ({
+                persistedStockEntity,
+                item,
+                statusName,
+              }))
+            )
+          )
+        );
+      }),
+      map(({ persistedStockEntity, item, statusName }) => {
+        const outputDto = new StockRegisterOutputDtoBuilder(
+          persistedStockEntity,
+          item
+        ).build();
+
+        return { outputDto, statusName };
+      }),
+      tap({
+        next: ({ outputDto, statusName }) =>
+          this.logger.log(
+            `Stock registered successfully for item ID: ${event.id} with status: ${statusName}, final stock ID: ${outputDto.id}`
+          ),
+        error: (error) =>
+          this.logger.error(
+            `Failed to register stock for item ${event.id}: ${error.message}`
+          ),
+      }),
+      map(({ outputDto }) => outputDto)
+    );
+  }
+
+  private determineStockStatus(eventSource: EventSource): string | undefined {
+    return EVENT_SOURCE_TO_STATUS[eventSource];
+  }
+
+  /**
+   * Stock entityを作成する
+   * @param item - アイテム情報
+   * @param status - ステータス情報
+   * @param event - アイテム作成イベント
+   * @returns Stock entity
+   */
+  private createStockEntity(
+    item: Items,
+    status: StockStatuses,
+    event: Pick<ItemCreatedEvent, 'id' | 'quantity' | 'description'>
+  ): Stock {
+    return Stock.create(
+      item.id,
+      Quantity.of(event.quantity),
+      event.description || '',
+      new StockStatus(
+        status.id,
+        status.name,
+        status.description || '',
+        status.createdAt,
+        status.updatedAt,
+        status.deletedAt
+      )
+    );
+  }
+
+  private throwIfItemNotFound = (): ItemNotFoundOperator => (source$) =>
+    source$.pipe(
+      filter((item: Items | null): item is Items => !!item),
+      defaultIfEmpty(null),
+      mergeMap((item) =>
+        item
+          ? [item]
+          : throwError(() => new NotFoundException('Item not found'))
+      )
+    );
+
+  private throwIfInvalidEventSource =
+    (eventSource: EventSource) => (source$: Observable<string | undefined>) =>
+      source$.pipe(
+        filter((statusName): statusName is string => !!statusName),
+        defaultIfEmpty(null),
+        mergeMap((statusName) => {
+          if (!statusName) {
+            this.logger.error(`Unknown event source: ${eventSource}`);
+            return throwError(
+              () => new Error(`Unknown event source: ${eventSource}`)
+            );
+          }
+          return of(statusName);
+        })
+      );
+
+  private throwIfStockStatusesNotFound =
+    (): StockStatusNotFoundOperator => (source$) =>
+      source$.pipe(
+        filter(
+          (status: StockStatuses | null): status is StockStatuses => !!status
+        ),
+        defaultIfEmpty(null),
+        mergeMap((status) =>
+          status
+            ? [status]
+            : throwError(() => new NotFoundException('Stock status not found'))
+        )
+      );
+
+  /**
+   * Stock entityを永続化する（stockIdを使ってドメインエンティティ構築）
+   * @param stockEntity - 永続化するStockエンティティ（UUID付き）
+   * @returns Observable<Stock> - 永続化されたStockエンティティ（DB ID付き）
+   */
+  private persistStockEntity(stockEntity: Stock): Observable<Stock> {
+    this.logger.log(
+      `Persisting stock entity with UUID: ${stockEntity.id}, hasTemporaryUUID: ${stockEntity.hasTemporaryUUID()}`
+    );
+
+    const persistenceData = this.extractPersistenceData(stockEntity);
+
+    return this.stocksDatasource
+      .createStockWithStatusIdInTransaction(
+        persistenceData.itemId,
+        persistenceData.quantity,
+        persistenceData.statusId,
+        persistenceData.description
+      )
+      .pipe(
+        switchMap((stockId) => {
+          const persistedStock = new Stock(
+            stockId, // 永続化されたDB ID
+            stockEntity.quantity,
+            stockEntity.description,
+            new Date(), // 永続化時の時刻
+            new Date(), // 永続化時の時刻
+            null, // deletedAt
+            stockEntity.itemId,
+            stockEntity.status
+          );
+
+          return of(persistedStock);
+        }),
+        tap((persistedStock) =>
+          this.logger.log(
+            `Stock persisted successfully. Original UUID: ${stockEntity.id} → DB ID: ${persistedStock.id}, isPersisted: ${persistedStock.isPersisted()}`
+          )
+        )
+      );
+  }
+
+  private extractPersistenceData(stockEntity: Stock) {
+    return {
+      itemId: stockEntity.itemId!,
+      quantity: stockEntity.quantity.value(),
+      statusId: stockEntity.status!.id,
+      description: stockEntity.description,
+    };
+  }
+}

--- a/src/common/types/rxjs-operator.types.ts
+++ b/src/common/types/rxjs-operator.types.ts
@@ -2,6 +2,7 @@ import { Items } from '../../infrastructure/orm/entities/items.entity';
 import { Categories } from '../../infrastructure/orm/entities/categories.entity';
 import { Category } from '../../domain/inventory/items/entities/category.entity';
 import { Stocks } from '../../infrastructure/orm/entities/stocks.entity';
+import { StockStatuses } from '../../infrastructure/orm/entities/stock.statuses.entity';
 import { OperatorFunction } from 'rxjs';
 
 export type ItemNotFoundOperator = OperatorFunction<Items | undefined, Items>;
@@ -14,6 +15,11 @@ export type ItemListNotFoundOperator = OperatorFunction<
 export type StockListNotFoundOperator = OperatorFunction<
   Stocks[] | undefined,
   Stocks[]
+>;
+
+export type StockStatusNotFoundOperator = OperatorFunction<
+  StockStatuses | undefined,
+  StockStatuses
 >;
 
 export type CategoryNotFoundOperator = OperatorFunction<

--- a/src/domain/inventory/stocks/entities/stock.entity.ts
+++ b/src/domain/inventory/stocks/entities/stock.entity.ts
@@ -1,8 +1,9 @@
 import { Quantity } from '../../items/value-objects/quantity';
 import { StockStatus } from './stock.status.entity';
+import { randomUUID } from 'crypto';
 
 export class Stock {
-  private readonly _id: number;
+  private readonly _id: number | string; // 永続化前はUUID（string）、永続化後はDB ID（number）
   private readonly _quantity: Quantity;
   private readonly _description: string;
   private readonly _createdAt: Date;
@@ -12,7 +13,7 @@ export class Stock {
   private readonly _status: StockStatus | null;
 
   constructor(
-    id: number,
+    id: number | string, // UUIDまたはDB ID
     quantity: Quantity,
     description: string,
     createdAt: Date,
@@ -32,7 +33,7 @@ export class Stock {
   }
 
   // Getters
-  get id(): number {
+  get id(): number | string {
     return this._id;
   }
 
@@ -62,5 +63,63 @@ export class Stock {
 
   get status(): StockStatus | null {
     return this._status;
+  }
+
+  /**
+   * 新規Stock entityを作成するfactoryメソッド
+   * @param itemId - 物品ID
+   * @param quantity - 数量
+   * @param description - 説明
+   * @param status - ステータス
+   * @returns Stock - 新規作成されたStockエンティティ
+   */
+  static create(
+    itemId: number,
+    quantity: Quantity,
+    description: string,
+    status: StockStatus
+  ): Stock {
+    const now = new Date();
+    const uuid = randomUUID(); // UUIDを生成
+
+    return new Stock(
+      uuid, // 永続化前は一意のUUID
+      quantity,
+      description,
+      now, // createdAt
+      now, // updatedAt
+      null, // deletedAt
+      itemId,
+      status
+    );
+  }
+
+  /**
+   * 永続化されたエンティティかどうかを判定する
+   * @returns boolean - 永続化されている場合はtrue
+   */
+  isPersisted(): boolean {
+    return typeof this._id === 'number';
+  }
+
+  /**
+   * 一時UUIDを持つかどうかを判定する
+   * @returns boolean - UUIDの場合はtrue
+   */
+  hasTemporaryUUID(): boolean {
+    return typeof this._id === 'string';
+  }
+
+  /**
+   * エンティティの同一性を比較する
+   * @param other - 比較対象のStockエンティティ
+   * @returns boolean - 同一エンティティの場合はtrue
+   */
+  equals(other: Stock): boolean {
+    if (!(other instanceof Stock)) {
+      return false;
+    }
+
+    return this._id === other._id;
   }
 }

--- a/src/infrastructure/datasources/items/items.datasource.interface.ts
+++ b/src/infrastructure/datasources/items/items.datasource.interface.ts
@@ -12,7 +12,16 @@ export const ITEMS_DATASOURCE_TOKEN = 'ItemsDatasourceInterface' as const;
  */
 export interface ItemsDatasourceInterface {
   /**
-   * アイテムIDの配列に基づいてアイテム情報を取得する
+   *
+   * @param itemIds アイテムIDの配列
+   * @returns アイテムIDの配列に基づいてアイテム情報を取得する
    */
   findItemsByIds(itemIds: number[]): Observable<Items[]>;
+
+  /**
+   * アイテムIDに基づいてアイテム情報を取得する
+   * @param id アイテムID
+   * @returns アイテム情報
+   */
+  findItemById(id: number): Observable<Items | undefined>;
 }

--- a/src/infrastructure/datasources/stocks/stocks.datasource.interface.ts
+++ b/src/infrastructure/datasources/stocks/stocks.datasource.interface.ts
@@ -1,5 +1,6 @@
 import { Observable } from 'rxjs';
 import { Stocks } from '../../orm/entities/stocks.entity';
+import { StockStatuses } from '../../orm/entities/stock.statuses.entity';
 import { Pagination } from '../../../domain/common/value-objects/pagination';
 import { SortOrder } from '../../../domain/common/value-objects/sort/sort.order';
 import { EntityManager } from 'typeorm';
@@ -38,6 +39,17 @@ export interface StocksDatasourceInterface {
   ): Observable<Stocks>;
 
   /**
+   * 物品IDと数量、ステータスを指定して在庫を更新、または新規作成する
+   */
+  createStockQuantityByItemIdWithStatus(
+    itemId: number,
+    quantity: number,
+    description?: string,
+    status?: string,
+    transactionalEntityManager?: EntityManager
+  ): Observable<Stocks>;
+
+  /**
    * 物品IDと数量を指定して、既存の在庫情報を更新
    */
   updateStockQuantityByItemId(
@@ -67,4 +79,21 @@ export interface StocksDatasourceInterface {
     quantity: number,
     transactionalEntityManager?: EntityManager
   ): Observable<void>;
+
+  /**
+   * ステータス名と一致するStockStatusesレコードを取得する
+   */
+  getStatusByName(name: string): Observable<StockStatuses | undefined>;
+
+  /**
+   * トランザクション内でステータスIDを指定して在庫を作成・更新する
+   * 永続化されたstockIdのみを返す
+   */
+  createStockWithStatusIdInTransaction(
+    itemId: number,
+    quantity: number,
+    statusId: number,
+    description?: string,
+    transactionalEntityManager?: EntityManager
+  ): Observable<number>;
 }

--- a/src/infrastructure/messaging/rabbitmq/subscriber/item.created.event.subscriber.ts
+++ b/src/infrastructure/messaging/rabbitmq/subscriber/item.created.event.subscriber.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { RabbitSubscribe } from '@golevelup/nestjs-rabbitmq';
 import { ItemCreatedEvent } from '../../../../application/services/item/events/item.created.event.publisher.interface';
-import { Observable } from 'rxjs';
+import { map, Observable } from 'rxjs';
 import { Inject } from '@nestjs/common';
 import { StockCreatedEventSubscriberInterface } from '../../../../application/services/stock/events/stock.created.event.subscriber.interface';
 
@@ -21,6 +21,6 @@ export class ItemCreatedEventSubscriber {
   })
   public handleItemCreated(event: ItemCreatedEvent): Observable<void> {
     this.logger.log(`Received item created event for item ID: ${event.id}`);
-    return this.stockCreatedHandler.handle(event);
+    return this.stockCreatedHandler.handle(event).pipe(map(() => void 0));
   }
 }

--- a/src/presentation/modules/stocks.module.ts
+++ b/src/presentation/modules/stocks.module.ts
@@ -12,6 +12,7 @@ import { ItemsDatasource } from '../../infrastructure/datasources/items/items.da
 import { STOCKS_DATASOURCE_TOKEN } from '../../infrastructure/datasources/stocks/stocks.datasource.interface';
 import { ITEMS_DATASOURCE_TOKEN } from '../../infrastructure/datasources/items/items.datasource.interface';
 import { StockListService } from '../../application/services/stock/stock.list.service';
+import { StockRegisterService } from '../../application/services/stock/stock.register.service';
 import { StockController } from '../controllers/stock/stock.controller';
 import { DatabaseModule } from './database.module';
 
@@ -30,6 +31,10 @@ import { DatabaseModule } from './database.module';
     {
       provide: 'StockListServiceInterface',
       useClass: StockListService,
+    },
+    {
+      provide: 'StockRegisterServiceInterface',
+      useClass: StockRegisterService,
     },
     {
       provide: 'StockQuantityUpdatedEventSubscriberInterface',
@@ -55,6 +60,7 @@ import { DatabaseModule } from './database.module';
   exports: [
     STOCKS_DATASOURCE_TOKEN,
     ITEMS_DATASOURCE_TOKEN,
+    'StockRegisterServiceInterface',
     'StockCreatedEventSubscriberInterface',
     'StockUpdatedEventSubscriberInterface',
     'StockDeletedEventSubscriberInterface',


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#101 
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- subscriberのサービスからstock.registerを呼べるように変更
- クエリの変更
- 単体テストの追加
# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
- 確認済み

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

## 動作したときのスクリーンショット
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
```
[Nest] 87176  - 2025/08/31 20:58:50     LOG [LoggerInterceptor.name] Request: [POST] /items
query: SELECT * FROM `items` `items` WHERE ( `items`.`name` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: ["エリック・エヴァンスのドメイン駆動設計"]
query: SELECT `categories`.`id` AS id, `categories`.`name` AS name, `categories`.`description` AS description, `categories`.`created_at` AS createdAt, `categories`.`updated_at` AS updatedAt, `categories`.`deleted_at` AS deletedAt FROM `categories` `categories` WHERE ( `categories`.`id` IN (?) AND `categories`.`deleted_at` IS NULL ) AND ( `categories`.`deleted_at` IS NULL ) -- PARAMETERS: [1]
query: START TRANSACTION
query: INSERT INTO `items`(`id`, `name`, `quantity`, `description`, `created_at`, `updated_at`, `deleted_at`) VALUES (DEFAULT, ?, ?, ?, ?, ?, ?) -- PARAMETERS: ["エリック・エヴァンスのドメイン駆動設計",1,"DDDのバイブル","2025-08-31T11:58:50.206Z","2025-08-31T11:58:50.206Z",null]
query: SELECT `Items`.`id` AS `Items_id`, `Items`.`deleted_at` AS `Items_deleted_at` FROM `items` `Items` WHERE ( `Items`.`id` = ? ) AND ( `Items`.`deleted_at` IS NULL ) -- PARAMETERS: [21]
query: INSERT INTO `item_categories`(`id`, `created_at`, `updated_at`, `deleted_at`, `item_id`, `category_id`) VALUES (DEFAULT, ?, ?, ?, ?, ?) -- PARAMETERS: ["2025-08-31T11:58:50.214Z","2025-08-31T11:58:50.214Z",null,21,1]
query: SELECT `ItemCategories`.`id` AS `ItemCategories_id`, `ItemCategories`.`deleted_at` AS `ItemCategories_deleted_at` FROM `item_categories` `ItemCategories` WHERE ( `ItemCategories`.`id` = ? ) AND ( `ItemCategories`.`deleted_at` IS NULL ) -- PARAMETERS: [11]
[Nest] 87176  - 2025/08/31 20:58:50     LOG [LoggerInterceptor.name] Request: [undefined] undefined
[Nest] 87176  - 2025/08/31 20:58:50     LOG Item registered & event published! ID: 21
[Nest] 87176  - 2025/08/31 20:58:50     LOG [LoggerInterceptor.name] Response: [POST] /items 37ms - {"id":21,"name":"エリック・エヴァンスのドメイン駆動設計","quantity":1,"description":"DDDのバイブル","createdAt":"2025-08-31T11:58:50.214Z","updatedAt":"2025-08-31T11:58:50.214Z","itemsCategories":[{"id":1,"name":"その他","description":"その他のカテゴリ"}]}
[Nest] 87176  - 2025/08/31 20:58:50     LOG [ItemCreatedEventSubscriber] Received item created event for item ID: 21
[Nest] 87176  - 2025/08/31 20:58:50     LOG [StockCreatedEventSubscriberService] Handling stock create event for item ID: 21
[Nest] 87176  - 2025/08/31 20:58:50     LOG [StockRegisterService] Registering stock for item ID: 21 from source: item.created
query: COMMIT
query: SELECT * FROM `items` `items` WHERE ( `items`.`id` = ? ) AND ( `items`.`deleted_at` IS NULL ) -- PARAMETERS: [21]
query: SELECT `stock_statuses`.`id` AS `stock_statuses_id`, `stock_statuses`.`name` AS `stock_statuses_name`, `stock_statuses`.`description` AS `stock_statuses_description`, `stock_statuses`.`created_at` AS `stock_statuses_created_at`, `stock_statuses`.`updated_at` AS `stock_statuses_updated_at`, `stock_statuses`.`deleted_at` AS `stock_statuses_deleted_at` FROM `stock_statuses` `stock_statuses` WHERE ( `stock_statuses`.`name` = ? ) AND ( `stock_statuses`.`deleted_at` IS NULL ) -- PARAMETERS: ["available"]
[Nest] 87176  - 2025/08/31 20:58:50     LOG [StockRegisterService] Created stock entity with UUID: cf324dbe-ab8f-498d-8672-a1158036b8af, isPersisted: false
[Nest] 87176  - 2025/08/31 20:58:50     LOG [StockRegisterService] Persisting stock entity with UUID: cf324dbe-ab8f-498d-8672-a1158036b8af, hasTemporaryUUID: true
query: INSERT INTO `stocks`(`id`, `quantity`, `description`, `created_at`, `updated_at`, `deleted_at`, `item_id`, `status_id`) VALUES (DEFAULT, ?, ?, ?, ?, DEFAULT, ?, ?) ON DUPLICATE KEY UPDATE `quantity` = VALUES(`quantity`), `description` = VALUES(`description`), `status_id` = VALUES(`status_id`), `updated_at` = VALUES(`updated_at`) -- PARAMETERS: [1,"DDDのバイブル","2025-08-31T11:58:50.235Z","2025-08-31T11:58:50.235Z",21,1]
query: SELECT `Stocks`.`id` AS `Stocks_id`, `Stocks`.`deleted_at` AS `Stocks_deleted_at` FROM `stocks` `Stocks` WHERE ( `Stocks`.`id` = ? ) AND ( `Stocks`.`deleted_at` IS NULL ) -- PARAMETERS: [11]
[Nest] 87176  - 2025/08/31 20:58:50     LOG [StockRegisterService] Stock persisted successfully. Original UUID: cf324dbe-ab8f-498d-8672-a1158036b8af → DB ID: 11, isPersisted: true
[Nest] 87176  - 2025/08/31 20:58:50     LOG [StockRegisterService] Converting persisted stock entity (ID: 11) to Output DTO using Builder pattern
[Nest] 87176  - 2025/08/31 20:58:50     LOG [StockRegisterService] Successfully built Output DTO using Builder constructor - ID: 11
[Nest] 87176  - 2025/08/31 20:58:50     LOG [StockRegisterService] Stock registered successfully for item ID: 21 with status: available, final stock ID: 11
[Nest] 87176  - 2025/08/31 20:58:50     LOG [LoggerInterceptor.name] Response: [undefined] undefined 19ms - undefined
```
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->